### PR TITLE
Add process event handler to replace node 12 unhandled exceptions flag

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,7 +1,13 @@
 const {listen} = require('../app');
 
+process.on('unhandledRejection', (reason, p) => {
+  // fix for node 10: https://stackoverflow.com/questions/51632965/can-i-get-the-future-unhandled-promise-rejection-behaviour-now
+  console.error('Unhandled Rejection at:', p, 'reason:', reason);
+  process.exit(1);
+});
+
 listen()
-    .catch(err => {
-        console.error(err);
-        process.exit(1);
-    });
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Integrated Pipeline Reports API",
   "main": "bin/server.js",
   "scripts": {
-    "start": "node --unhandled-rejections=strict --max-old-space-size=2800 bin/server.js",
+    "start": "node --max-old-space-size=2800 bin/server.js",
     "start:prod": "NODE_ENV=production node --max-old-space-size=2800 bin/server.js",
     "start:dev": "NODE_ENV=development node --max-old-space-size=2800 bin/server.js",
     "test": "NODE_ENV=test jest --config config/jest/jest.config.js --detectOpenHandles --forceExit",


### PR DESCRIPTION
BugFix
- use node10 compatible unhandled process rejection

Note: we discussed moving to node 12 but this turned out to be simple enough anyway and this way we are compatible with 10 and 12