### PR TITLE
Add option to filter germline reports by biofx review & non-exported

### DIFF
--- a/app/routes/germlineSmallMutation/reports.js
+++ b/app/routes/germlineSmallMutation/reports.js
@@ -122,7 +122,7 @@ router.route('/')
         {
           as: 'reviews',
           model: db.models.germlineSmallMutationReview,
-          where: {type: reviewType},
+          where: {type: reviewType.split(',') || reviewType},
           attributes: {exclude: ['id', 'germlineReportId', 'reviewerId', 'deletedAt']},
           include: [{model: db.models.user.scope('public'), as: 'reviewer'}],
         },

--- a/app/routes/germlineSmallMutation/reports.js
+++ b/app/routes/germlineSmallMutation/reports.js
@@ -84,7 +84,7 @@ router.route('/')
   .get(async (req, res) => {
     const {
       query: {
-        limit, offset, patientId, biopsyName, project,
+        limit, offset, patientId, biopsyName, project, reviewFilter,
       },
     } = req;
 
@@ -98,6 +98,7 @@ router.route('/')
       where: {
         ...((patientId) ? {patientId: {[Op.iLike]: `%${patientId}%`}} : {}),
         ...((biopsyName) ? {biopsyName: {[Op.iLike]: `%${biopsyName}%`}} : {}),
+        ...((reviewFilter) ? {exported: {[Op.eq]: false}} : {}),
       },
       include: [],
       distinct: 'id',
@@ -115,7 +116,7 @@ router.route('/')
     }
 
     // Check if filtering by review
-    if (inProjectsGroup) {
+    if (inProjectsGroup || reviewFilter) {
       opts.include.push(
         {
           as: 'reviews',

--- a/app/routes/germlineSmallMutation/reports.js
+++ b/app/routes/germlineSmallMutation/reports.js
@@ -98,7 +98,7 @@ router.route('/')
       where: {
         ...((patientId) ? {patientId: {[Op.iLike]: `%${patientId}%`}} : {}),
         ...((biopsyName) ? {biopsyName: {[Op.iLike]: `%${biopsyName}%`}} : {}),
-        ...((exported !== undefined) ? {exported: {[Op.eq]: exported}} : {}),
+        ...((typeof exported === 'boolean') ? {exported} : {}),
       },
       include: [],
       distinct: 'id',

--- a/app/routes/swagger/swagger.json
+++ b/app/routes/swagger/swagger.json
@@ -2066,6 +2066,31 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "name": "exported",
+            "in": "query",
+            "required": false,
+            "description": "Returns reports with exported set to true/false",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "reviewType",
+            "in": "query",
+            "required": false,
+            "description": "Returns reports with reviews of type reviewType",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array"
+                }
+              ]
+            }
           }
         ],
         "security": [

--- a/test/routes/germlineSmallMutation/index.test.js
+++ b/test/routes/germlineSmallMutation/index.test.js
@@ -169,6 +169,56 @@ describe.skip('/germline-small-mutation-reports', () => {
       }
     });
 
+    test('/ - exported query - 200 success', async () => {
+      const res = await request
+        .get(BASE_URI)
+        .query({exported: false})
+        .auth(username, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      expect(res.body).toEqual(checkGermlineReportList);
+      expect(res.body.reports).toEqual(expect.arrayContaining([
+        expect.objectContaining({exported: false}),
+      ]));
+    });
+
+    test('/ - reviewType string query - 200 success', async () => {
+      const res = await request
+        .get(BASE_URI)
+        .query({reviewType: 'biofx'})
+        .auth(username, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      expect(res.body).toEqual(checkGermlineReportList);
+      expect(res.body.reports).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          reviews: expect.arrayContaining([
+            expect.objectContaining({type: expect.stringContaining('biofx')}),
+          ]),
+        }),
+      ]));
+    });
+
+    test('/ - reviewType array query - 200 success', async () => {
+      const res = await request
+        .get(BASE_URI)
+        .query({reviewType: 'biofx,projects'})
+        .auth(username, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      expect(res.body).toEqual(checkGermlineReportList);
+      expect(res.body.reports).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          reviews: expect.arrayContaining([
+            expect.objectContaining({type: expect.stringMatching(/(biofx|projects)/)}),
+          ]),
+        }),
+      ]));
+    });
+
     test('/{gsm_report} - 200 Success', async () => {
       const res = await request
         .get(`${BASE_URI}/${report.ident}`)


### PR DESCRIPTION
This will allow for the client to send the `reviewFilter` option and return reports with a biofx review that haven't been exported