### PR TITLE
feature/DEVSU-2180-change-report-to-ready-on-edit

### DIFF
--- a/app/models/base.js
+++ b/app/models/base.js
@@ -171,6 +171,20 @@ const DEFAULT_REPORT_OPTIONS = {
             transaction: options.transaction,
             userId: options.userId,
           }),
+        // If report is state "reviewed" change to "ready"
+        (!changed || includesAll(updateExclude, changed)) ? Promise.resolve(true)
+          : instance.sequelize.models.report.update({
+            state: 'ready',
+          }, {
+            where: {
+              id: (modelName === 'report') ? instance.id : instance.reportId,
+              state: 'reviewed',
+            },
+            individualHooks: true,
+            paranoid: true,
+            transaction: options.transaction,
+            userId: options.userId,
+          }),
       ]);
     },
     afterCreate: async (instance, options = {}) => {

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -547,19 +547,21 @@ describe('/reports/{REPORTID}', () => {
 
       checkReport(res.body);
       expect(res.body).toHaveProperty('state', 'ready');
+    });
 
-      test('state NOT updated to ready when NOT reviewed OK', async () => {
-        const res = await request
-          .put(`/api/reports/${reportCompleted.ident}`)
-          .auth(username, password)
-          .type('json')
-          .send({
-            tumourContent: 42.2,
-          })
-          .expect(HTTP_STATUS.OK);
-  
-        checkReport(res.body);
-        expect(res.body).toHaveProperty('state', 'completed');
+    test('state NOT updated to ready when NOT reviewed OK', async () => {
+      const res = await request
+        .put(`/api/reports/${reportCompleted.ident}`)
+        .auth(username, password)
+        .type('json')
+        .send({
+          tumourContent: 42.2,
+        })
+        .expect(HTTP_STATUS.OK);
+
+      checkReport(res.body);
+      expect(res.body).toHaveProperty('state', 'completed');
+    });
 
     test('tumour content update OK', async () => {
       const res = await request

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -535,6 +535,32 @@ describe('/reports/{REPORTID}', () => {
   });
 
   describe('PUT', () => {
+    test('state updated to ready when reviewed OK', async () => {
+      const res = await request
+        .put(`/api/reports/${reportReviewed.ident}`)
+        .auth(username, password)
+        .type('json')
+        .send({
+          tumourContent: 42.2,
+        })
+        .expect(HTTP_STATUS.OK);
+
+      checkReport(res.body);
+      expect(res.body).toHaveProperty('state', 'ready');
+
+      test('state NOT updated to ready when NOT reviewed OK', async () => {
+        const res = await request
+          .put(`/api/reports/${reportCompleted.ident}`)
+          .auth(username, password)
+          .type('json')
+          .send({
+            tumourContent: 42.2,
+          })
+          .expect(HTTP_STATUS.OK);
+  
+        checkReport(res.body);
+        expect(res.body).toHaveProperty('state', 'completed');
+
     test('tumour content update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)


### PR DESCRIPTION
Features:
- If report is state "reviewed" change to "ready" when signatures are removed