### PR TITLE
DEVSU-2236 Add Selected Field to Somatic Variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ mocha.json
 jsdoc
 .vscode/
 .env.sh
+config/config.json

--- a/app/models/reports/copyVariants.js
+++ b/app/models/reports/copyVariants.js
@@ -78,6 +78,11 @@ module.exports = (sequelize, Sq) => {
       field: 'display_name',
       type: Sq.TEXT,
     },
+    selected: {
+      type: Sq.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
   }, {
     ...DEFAULT_REPORT_OPTIONS,
     tableName: 'reports_copy_variants',

--- a/app/models/reports/expressionVariants.js
+++ b/app/models/reports/expressionVariants.js
@@ -184,6 +184,11 @@ module.exports = (sequelize, Sq) => {
       field: 'display_name',
       type: Sq.TEXT,
     },
+    selected: {
+      type: Sq.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
   }, {
     ...DEFAULT_REPORT_OPTIONS,
     tableName: 'reports_expression_variants',

--- a/app/models/reports/mutationSignature.js
+++ b/app/models/reports/mutationSignature.js
@@ -45,6 +45,7 @@ module.exports = (sequelize, Sq) => {
     selected: {
       type: Sq.BOOLEAN,
       defaultValue: false,
+      allowNull: false,
     },
   }, {
     ...DEFAULT_REPORT_OPTIONS,

--- a/app/models/reports/smallMutations.js
+++ b/app/models/reports/smallMutations.js
@@ -145,6 +145,11 @@ module.exports = (sequelize, Sq) => {
       field: 'display_name',
       type: Sq.TEXT,
     },
+    selected: {
+      type: Sq.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
   }, {
     ...DEFAULT_REPORT_OPTIONS,
     tableName: 'reports_small_mutations',

--- a/app/models/reports/structuralVariants.js
+++ b/app/models/reports/structuralVariants.js
@@ -133,6 +133,11 @@ module.exports = (sequelize, Sq) => {
       field: 'display_name',
       type: Sq.TEXT,
     },
+    selected: {
+      type: Sq.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
   }, {
     ...DEFAULT_REPORT_OPTIONS,
     tableName: 'reports_structural_variants',

--- a/migrations/20240307183008-DEVSU-2236-add-selected-to-somatic-variants.js
+++ b/migrations/20240307183008-DEVSU-2236-add-selected-to-somatic-variants.js
@@ -1,0 +1,66 @@
+const mutationSignatureTable = 'reports_mutation_signature';
+const smallMutationsTable = 'reports_small_mutations';
+const structuralVariantsTable = 'reports_structural_variants';
+const copyVariantsTable = 'reports_copy_variants';
+const expressionVariantsTable = 'reports_expression_variants';
+
+module.exports = {
+  up: async (queryInterface, Sq) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.changeColumn(
+        mutationSignatureTable,
+        'selected',
+        {
+          type: Sq.BOOLEAN,
+          defaultValue: false,
+          allowNull: false,
+        },
+        {transaction},
+      );
+      await queryInterface.addColumn(
+        smallMutationsTable,
+        'selected',
+        {
+          type: Sq.BOOLEAN,
+          defaultValue: false,
+          allowNull: false,
+        },
+        {transaction},
+      );
+      await queryInterface.addColumn(
+        structuralVariantsTable,
+        'selected',
+        {
+          type: Sq.BOOLEAN,
+          defaultValue: false,
+          allowNull: false,
+        },
+        {transaction},
+      );
+      await queryInterface.addColumn(
+        copyVariantsTable,
+        'selected',
+        {
+          type: Sq.BOOLEAN,
+          defaultValue: false,
+          allowNull: false,
+        },
+        {transaction},
+      );
+      await queryInterface.addColumn(
+        expressionVariantsTable,
+        'selected',
+        {
+          type: Sq.BOOLEAN,
+          defaultValue: false,
+          allowNull: false,
+        },
+        {transaction},
+      );
+    });
+  },
+
+  down: async () => {
+    throw new Error('Not Implemented!');
+  },
+};

--- a/test/routes/report/copyVariants.test.js
+++ b/test/routes/report/copyVariants.test.js
@@ -37,7 +37,7 @@ const copyVariantProperties = [
   'ident', 'createdAt', 'updatedAt', 'copyChange',
   'lohState', 'cnvState', 'chromosomeBand', 'start',
   'end', 'size', 'kbCategory', 'log2Cna', 'cna', 'gene',
-  'germline', 'library', 'comments', 'displayName',
+  'germline', 'library', 'comments', 'displayName', 'selected',
 ];
 
 const checkCopyVariant = (variantObject) => {

--- a/test/routes/report/expressionVariants.test.js
+++ b/test/routes/report/expressionVariants.test.js
@@ -29,7 +29,7 @@ const expressionVariantProperties = ['ident', 'gene', 'location', 'rnaReads', 'r
   'biopsySiteQC', 'biopsySiteFoldChange', 'biopsySiteZScore',
   'internalPancancerPercentile', 'internalPancancerkIQR', 'internalPancancerQC',
   'internalPancancerFoldChange', 'internalPancancerZScore', 'kbCategory', 'germline',
-  'library', 'comments', 'displayName', 'gene'];
+  'library', 'comments', 'displayName', 'gene', 'selected'];
 
 const checkExpressionVariant = (variantObject) => {
   expressionVariantProperties.forEach((element) => {

--- a/test/routes/report/smallMutations.test.js
+++ b/test/routes/report/smallMutations.test.js
@@ -24,7 +24,7 @@ const UPDATE_DATA = {
 const smallMutationProperties = ['transcript', 'proteinChange', 'chromosome', 'startPosition',
   'endPosition', 'refSeq', 'altSeq', 'zygosity', 'tumourAltCount', 'tumourRefCount', 'tumourDepth',
   'rnaAltCount', 'rnaRefCount', 'rnaDepth', 'normalAltCount', 'normalRefCount', 'normalDepth',
-  'hgvsProtein', 'hgvsCds', 'hgvsGenomic', 'ncbiBuild', 'germline',
+  'hgvsProtein', 'hgvsCds', 'hgvsGenomic', 'ncbiBuild', 'germline', 'selected',
   'tumourAltCopies', 'tumourRefCopies', 'library', 'comments', 'displayName', 'gene'];
 
 const checkSmallMutation = (variantObject) => {

--- a/test/routes/report/structuralVariants.test.js
+++ b/test/routes/report/structuralVariants.test.js
@@ -24,7 +24,7 @@ const UPDATE_DATA = {
 const structuralVariantProperties = ['exon1', 'exon2', 'breakpoint', 'eventType', 'detectedIn',
   'conventionalName', 'svg', 'svgTitle', 'name', 'frame', 'ctermGene',
   'ntermGene', 'ctermTranscript', 'ntermTranscript', 'omicSupport',
-  'highQuality', 'germline', 'library', 'tumourAltCount',
+  'highQuality', 'germline', 'library', 'tumourAltCount', 'selected',
   'tumourDepth', 'rnaAltCount', 'rnaDepth', 'comments', 'displayName', 'gene1', 'gene2'];
 
 const checkStructuralVariant = (variantObject) => {

--- a/test/testData/mockReportData.json
+++ b/test/testData/mockReportData.json
@@ -330,7 +330,8 @@
             "germline": false,
             "tumourRefCopies": 60,
             "tumourAltCopies": 20,
-            "library": "TEST LIBRARY"
+            "library": "TEST LIBRARY",
+            "selected": false
         }
     ],
     "mutationSignature": [
@@ -359,7 +360,8 @@
             "size": 0.09,
             "kbCategory": "Test Category",
             "germline": false,
-            "library": "TEST LIBRARY"
+            "library": "TEST LIBRARY",
+            "selected": false
         }
     ],
     "mavis": [
@@ -392,7 +394,8 @@
             "tumourAltCount": 4,
             "tumourDepth": 590,
             "rnaAltCount": 5,
-            "rnaDepth": 591
+            "rnaDepth": 591,
+            "selected": false
         }
     ],
     "proteinVariants": [
@@ -436,7 +439,8 @@
             "rpkm": 1889.11,
             "tpm": 12.3,
             "germline": true,
-            "library": "TEST LIBRARY"
+            "library": "TEST LIBRARY",
+            "selected": false
         }
     ],
     "probeTestInformation": [


### PR DESCRIPTION
- Add 'selected' fields to smallMutations, structuralVariants, copyVariants, and expressionVariants tables
- Add allowNull: false enforcement to 'selected' field in mutationSignatures
- Update MockReportData and subsequent tests for new fields