### PR TITLE
Feat/devsu 2099 add signature graphkb search for to table

### DIFF
--- a/app/api/graphkb.js
+++ b/app/api/graphkb.js
@@ -32,6 +32,8 @@ const graphkbAutocomplete = async (targetType, graphkbToken, keyword = null) => 
       delete query.limit; // short list with short names, just return all
     } else if (targetType === 'therapy') {
       query.target = 'Therapy';
+    } else if (targetType === 'signature') {
+      query.target = 'Signature';
     } else {
       query.target = 'Variant';
       query.returnProperties.push(...[

--- a/app/models/reports/genomic/summary/therapeuticTargets.js
+++ b/app/models/reports/genomic/summary/therapeuticTargets.js
@@ -42,6 +42,16 @@ module.exports = (sequelize, Sq) => {
       defaultValue: null,
       field: 'variant_graphkb_id',
     },
+    signature: {
+      type: Sq.TEXT,
+      defaultValue: null,
+    },
+    signatureGraphkbId: {
+      name: 'signatureGraphkbId',
+      type: Sq.TEXT,
+      defaultValue: null,
+      field: 'signature_graphkb_id',
+    },
     therapy: {
       type: Sq.STRING,
       allowNull: false,

--- a/app/routes/graphkb/index.js
+++ b/app/routes/graphkb/index.js
@@ -13,7 +13,7 @@ router.use(loginMiddleware);
  * Autocomplete endpoint for interfacing with GraphKB. This endpoint is used by the client
  * for the therapeutic options input forms
  */
-router.get('/:targetType(variant|therapy|evidenceLevel|context)', async (req, res) => {
+router.get('/:targetType(variant|signature|therapy|evidenceLevel|context)', async (req, res) => {
   try {
     const data = await graphkbAutocomplete(
       req.params.targetType,

--- a/app/routes/report/therapeuticTargets.js
+++ b/app/routes/report/therapeuticTargets.js
@@ -47,23 +47,19 @@ router.route('/:target([A-z0-9-]{36})')
   })
   .put(async (req, res) => {
     // Validate request against schema
-    console.log('in put at 50');
     try {
       validateAgainstSchema(updateSchema, req.body, false);
     } catch (error) {
       logger.error(`Error while validating target update request ${error}`);
       return res.status(HTTP_STATUS.BAD_REQUEST).json({error: {message: `Error while validating target update request ${error}`}});
     }
-    console.log('in put at 57');
 
     if ((req.body.gene || req.body.gene_graphkb_id) && (req.body.signature || req.body.signature_graphkb_id)) {
       const msg = 'Can not set both signature and gene values in therapeutics target table';
       logger.error(msg);
       return res.status(HTTP_STATUS.BAD_REQUEST).json({error: {message: msg}});
     }
-    console.log('in put at 64');
 
-    console.log('target');
     const reqHasGene = (req.body.gene || req.body.gene_graphkb_id);
     const reqHasSignature = (req.body.signature || req.body.signature_graphkb_id);
 
@@ -113,7 +109,6 @@ router.route('/')
   })
   .post(async (req, res) => {
     // Create new entry
-    console.log('in post at 124');
     const {report: {id: reportId}, body} = req;
     // Validate request against schema
     try {
@@ -140,10 +135,8 @@ router.route('/')
         rank,
         reportId,
       });
-      console.log('made it up to return without error at 152');
       return res.status(HTTP_STATUS.CREATED).json(result.view('public'));
     } catch (error) {
-      console.log('in error no wthough');
       logger.error(`Unable to create new therapeutic target entry ${error}`);
       return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({error: {message: 'Unable to create new therapeutic target entry'}});
     }

--- a/app/routes/report/therapeuticTargets.js
+++ b/app/routes/report/therapeuticTargets.js
@@ -60,16 +60,13 @@ router.route('/:target([A-z0-9-]{36})')
       return res.status(HTTP_STATUS.BAD_REQUEST).json({error: {message: msg}});
     }
 
-    const reqHasGene = (req.body.gene || req.body.gene_graphkb_id);
-    const reqHasSignature = (req.body.signature || req.body.signature_graphkb_id);
-
     try {
-      if (reqHasGene) {
+      if (req.body.gene || req.body.gene_graphkb_id) {
         req.body.signature = null;
-        req.body.signature_graphkb_id = null;
-      } else if (reqHasSignature) {
+        req.body.signatureGraphkbId = null;
+      } else if (req.body.signature || req.body.signature_graphkb_id) {
         req.body.gene = null;
-        req.body.gene_graphkb_id = null;
+        req.body.geneGraphkbId = null;
       }
       await req.target.update(req.body, {userId: req.user.id});
       return res.json(req.target.view('public'));

--- a/migrations/20240510203951-devsu-2099-add-signature-to-pto-table.js
+++ b/migrations/20240510203951-devsu-2099-add-signature-to-pto-table.js
@@ -1,4 +1,4 @@
-const TABLE = 'reports_therapeutic_options';
+const TABLE = 'reports_therapeutic_targets';
 
 module.exports = {
   up: async (queryInterface, Sq) => {

--- a/migrations/20240510203951-devsu-2099-add-signature-to-pto-table.js
+++ b/migrations/20240510203951-devsu-2099-add-signature-to-pto-table.js
@@ -1,0 +1,30 @@
+const TABLE = 'reports_therapeutic_options';
+
+module.exports = {
+  up: async (queryInterface, Sq) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        TABLE,
+        'signature',
+        {
+          type: Sq.TEXT,
+          defaultValue: null,
+        },
+        {transaction},
+      );
+      await queryInterface.addColumn(
+        TABLE,
+        'signature_graphkb_id',
+        {
+          type: Sq.TEXT,
+          defaultValue: null,
+        },
+        {transaction},
+      );
+    });
+  },
+
+  down: async () => {
+    throw new Error('Not Implemented!');
+  },
+};

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -96,11 +96,7 @@ describe('/reports/{REPORTID}', () => {
         name: 'TEST2',
       },
     });
-    offsetTestProject = await db.models.project.create({
-      where: {
-        name: `offset${stringify(randomUuid)}`,
-      }
-    })
+    offsetTestProject = await db.models.project.create({name: `offset${randomUuid.toString()}`})
 
     report = await db.models.report.create({
       templateId: template.id,

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -83,6 +83,7 @@ describe('/reports/{REPORTID}', () => {
 
   beforeAll(async () => {
     // Get genomic template
+    console.log('check here 86');
     const template = await db.models.template.findOne({where: {name: 'genomic'}});
     // Create Report and associate projects
     project = await db.models.project.findOne({
@@ -96,6 +97,7 @@ describe('/reports/{REPORTID}', () => {
       },
     });
     offsetTestProject = await db.models.project.create({name: `offset${randomUuid.toString()}`});
+    console.log('check here 100');
 
     report = await db.models.report.create({
       templateId: template.id,
@@ -117,6 +119,7 @@ describe('/reports/{REPORTID}', () => {
       reportId: reportReady.id,
       project_id: project.id,
     });
+    console.log('check here 122');
 
     reportNonProduction = await db.models.report.create({
       templateId: template.id,
@@ -162,6 +165,7 @@ describe('/reports/{REPORTID}', () => {
       project_id: project2.id,
       additionalProject: true,
     });
+    console.log('check here 168');
 
     // create a second set of reports for use in the offset test, which relies on
     // a predictable set of reports in the db which means using a specific project
@@ -198,6 +202,7 @@ describe('/reports/{REPORTID}', () => {
       project_id: offsetTestProject.id,
     });
 
+    console.log('check here 205');
     reportReviewed2 = await db.models.report.create({
       templateId: template.id,
       patientId: mockReportData.patientId,
@@ -217,11 +222,13 @@ describe('/reports/{REPORTID}', () => {
       reportId: reportCompleted2.id,
       project_id: offsetTestProject.id,
     });
+    console.log('check here 224');
+
   }, LONGER_TIMEOUT);
 
   describe('GET', () => {
     // Test regular GET
-    test('/ - 200 Success', async () => {
+    test.skip('/ - 200 Success', async () => {
       const res = await request
         .get('/api/reports')
         .auth(username, password)
@@ -232,7 +239,7 @@ describe('/reports/{REPORTID}', () => {
     }, LONGER_TIMEOUT);
 
     // Test GET with paginated
-    test('/ - paginated - 400 Bad Request', async () => {
+    test.skip('/ - paginated - 400 Bad Request', async () => {
       await request
         .get('/api/reports?paginated=NOT_BOOLEAN')
         .auth(username, password)
@@ -240,7 +247,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.BAD_REQUEST);
     });
 
-    test('/ - 200 GET non-production reports with "non-production access" group', async () => {
+    test.skip('/ - 200 GET non-production reports with "non-production access" group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -255,7 +262,7 @@ describe('/reports/{REPORTID}', () => {
       expect(checkState(res.body.reports, 'nonproduction')).toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test('/ - 200 NOT GET non-production reports with non-authorized group', async () => {
+    test.skip('/ - 200 NOT GET non-production reports with non-authorized group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -270,7 +277,7 @@ describe('/reports/{REPORTID}', () => {
       expect(checkState(res.body.reports, 'nonproduction')).not.toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test('/ - 200 GET report if have additional report permission', async () => {
+    test.skip('/ - 200 GET report if have additional report permission', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -289,7 +296,7 @@ describe('/reports/{REPORTID}', () => {
       ).length > 0).toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test('/ - 200 GET unreviewed reports with "unreviewed access" group', async () => {
+    test.skip('/ - 200 GET unreviewed reports with "unreviewed access" group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -304,7 +311,7 @@ describe('/reports/{REPORTID}', () => {
       expect(checkState(res.body.reports, 'ready')).toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test('/ - 200 NOT GET unreviewed reports with non-authorized group', async () => {
+    test.skip('/ - 200 NOT GET unreviewed reports with non-authorized group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -320,7 +327,7 @@ describe('/reports/{REPORTID}', () => {
     }, LONGER_TIMEOUT);
 
     // Test GET with limit
-    test('/ - limit - 200 Success', async () => {
+    test.skip('/ - limit - 200 Success', async () => {
       const res = await request
         .get('/api/reports?paginated=true&limit=4')
         .auth(username, password)
@@ -331,7 +338,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports.length).toBeLessThanOrEqual(4);
     }, LONGER_TIMEOUT);
 
-    test('/ - limit - 400 Bad Request', async () => {
+    test.skip('/ - limit - 400 Bad Request', async () => {
       await request
         .get('/api/reports?paginated=true&limit=NOT_INTEGER')
         .auth(username, password)
@@ -339,7 +346,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.BAD_REQUEST);
     });
 
-    test('/ - offset - 200 Success', async () => {
+    test.skip('/ - offset - 200 Success', async () => {
       const totalOffsetReports = 5;
       const res = await request
         .get(`/api/reports?project=${offsetTestProject.name}&paginated=true&offset=${totalOffsetReports - 3}`)
@@ -351,7 +358,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports.length).toBe(3);
     }, LONGER_TIMEOUT);
 
-    test('/ - offset - 400 Bad Request', async () => {
+    test.skip('/ - offset - 400 Bad Request', async () => {
       await request
         .get('/api/reports?paginated=true&offset=NOT_INTEGER')
         .auth(username, password)
@@ -360,7 +367,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with sort
-    test('/ - sort - 200 Success', async () => {
+    test.skip('/ - sort - 200 Success', async () => {
       const res = await request
         .get('/api/reports?sort=patientId:desc')
         .auth(username, password)
@@ -371,7 +378,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports[0].patientId).toEqual(res.body.reports[1].patientId);
     }, LONGER_TIMEOUT);
 
-    test('/ - sort - 400 Bad Request', async () => {
+    test.skip('/ - sort - 400 Bad Request', async () => {
       await request
         .get('/api/reports?sort=INVALID_FIELD:desc')
         .auth(username, password)
@@ -380,7 +387,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with project
-    test('/ - project - 200 Success', async () => {
+    test.skip('/ - project - 200 Success', async () => {
       const res = await request
         .get('/api/reports?project=TEST')
         .auth(username, password)
@@ -396,7 +403,7 @@ describe('/reports/{REPORTID}', () => {
       ]));
     });
 
-    test('/ - project - 403 Forbidden', async () => {
+    test.skip('/ - project - 403 Forbidden', async () => {
       await request
         .get('/api/reports?project=SUPER-SECURE')
         .auth(username, password)
@@ -405,7 +412,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with states
-    test('/ - states - 200 Success', async () => {
+    test.skip('/ - states - 200 Success', async () => {
       const res = await request
         .get('/api/reports?states=ready')
         .auth(username, password)
@@ -419,7 +426,7 @@ describe('/reports/{REPORTID}', () => {
       ]));
     }, LONGER_TIMEOUT);
 
-    test('/ - states - 400 Bad Request', async () => {
+    test.skip('/ - states - 400 Bad Request', async () => {
       await request
         .get('/api/reports?states=INVALID_STATE')
         .auth(username, password)
@@ -428,7 +435,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with role
-    test('/ - role - 200 Success', async () => {
+    test.skip('/ - role - 200 Success', async () => {
       const res = await request
         .get('/api/reports?role=clinician')
         .auth(username, password)
@@ -440,7 +447,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports).toEqual([]);
     }, LONGER_TIMEOUT);
 
-    test('/ - role - 400 Bad Request', async () => {
+    test.skip('/ - role - 400 Bad Request', async () => {
       await request
         .get('/api/reports?role=INVALID_ROLE')
         .auth(username, password)
@@ -449,7 +456,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with search text
-    test('/ - search text - 200 Success', async () => {
+    test.skip('/ - search text - 200 Success', async () => {
       const res = await request
         .get('/api/reports?searchText=UPLOADPAT01')
         .auth(username, password)
@@ -463,7 +470,7 @@ describe('/reports/{REPORTID}', () => {
       ]));
     }, LONGER_TIMEOUT);
 
-    test('fetches known ident ok', async () => {
+    test.skip('fetches known ident ok', async () => {
       const res = await request
         .get(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -473,7 +480,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test('fetches additional project permission ok', async () => {
+    test.skip('fetches additional project permission ok', async () => {
       const res = await request
         .get(`/api/reports/${reportDualProj.ident}`)
         .query({
@@ -487,7 +494,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test('fetches non-production ident with group OK', async () => {
+    test.skip('fetches non-production ident with group OK', async () => {
       const res = await request
         .get(`/api/reports/${reportNonProduction.ident}`)
         .query({
@@ -501,7 +508,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test('error on non-production ident with wrong group', async () => {
+    test.skip('error on non-production ident with wrong group', async () => {
       await request
         .get(`/api/reports/${reportNonProduction.ident}`)
         .query({
@@ -513,7 +520,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
-    test('fetches unreviewed ident with group OK', async () => {
+    test.skip('fetches unreviewed ident with group OK', async () => {
       const res = await request
         .get(`/api/reports/${reportReady.ident}`)
         .query({
@@ -527,7 +534,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test('error on unreviewed ident with wrong group', async () => {
+    test.skip('error on unreviewed ident with wrong group', async () => {
       await request
         .get(`/api/reports/${reportReady.ident}`)
         .query({
@@ -553,14 +560,14 @@ describe('/reports/{REPORTID}', () => {
       const expectedReports = [report, reportReady, reportReviewed, reportCompleted, reportNonProduction, report2, reportReady2, reportReviewed2, reportCompleted2, reportNonProduction2, reportDualProj];
       expect(res.body.total).toBeGreaterThanOrEqual(expectedReports.length);
 
-      const expectedIds = (expectedReports).map((elem) => {return elem.id;});
-      const foundIds = (res.body).map((elem) => {return elem.id;});
+      const expectedIds = (expectedReports).map((elem) => {return elem.ident;});
+      const foundIds = (res.body.reports).map((elem) => {return elem.ident;});
 
       const allPresent = expectedIds.every((elem) => {return foundIds.includes(elem);});
       expect(allPresent).toBeTruthy();
     });
 
-    test('State querying is OK', async () => {
+    test.skip('State querying is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
       const res = await request
         .get('/api/reports')
@@ -574,7 +581,7 @@ describe('/reports/{REPORTID}', () => {
       });
     });
 
-    test('Multiple queries is OK', async () => {
+    test.skip('Multiple queries is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
       const res = await request
         .get('/api/reports')
@@ -594,7 +601,7 @@ describe('/reports/{REPORTID}', () => {
       });
     });
 
-    test('error on non-existant ident', async () => {
+    test.skip('error on non-existant ident', async () => {
       await request
         .get(`/api/reports/${randomUuid}`)
         .auth(username, password)
@@ -604,7 +611,7 @@ describe('/reports/{REPORTID}', () => {
   });
 
   describe('PUT', () => {
-    test('state updated to ready when reviewed OK', async () => {
+    test.skip('state updated to ready when reviewed OK', async () => {
       const res = await request
         .put(`/api/reports/${reportReviewed.ident}`)
         .auth(username, password)
@@ -618,7 +625,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('state', 'ready');
     });
 
-    test('state NOT updated to ready when NOT reviewed OK', async () => {
+    test.skip('state NOT updated to ready when NOT reviewed OK', async () => {
       const res = await request
         .put(`/api/reports/${reportCompleted.ident}`)
         .auth(username, password)
@@ -632,7 +639,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('state', 'completed');
     });
 
-    test('tumour content update OK', async () => {
+    test.skip('tumour content update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -646,7 +653,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('tumourContent', 23.2);
     });
 
-    test('completed report update OK', async () => {
+    test.skip('completed report update OK', async () => {
       const res = await request
         .put(`/api/reports/${reportCompleted.ident}`)
         .auth(username, password)
@@ -660,7 +667,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('tumourContent', 23.2);
     });
 
-    test('completed report update FORBIDDEN', async () => {
+    test.skip('completed report update FORBIDDEN', async () => {
       await request
         .put(`/api/reports/${reportCompleted.ident}`)
         .query({
@@ -675,7 +682,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
-    test('M1M2 Score update OK', async () => {
+    test.skip('M1M2 Score update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -689,7 +696,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('m1m2Score', 98.5);
     });
 
-    test('ploidy update OK', async () => {
+    test.skip('ploidy update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -703,7 +710,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('ploidy', 'triploid');
     });
 
-    test('subtyping update OK', async () => {
+    test.skip('subtyping update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -717,7 +724,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('subtyping', 'ER positive');
     });
 
-    test('error on unexpected value', async () => {
+    test.skip('error on unexpected value', async () => {
       await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -346,8 +346,6 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.BAD_REQUEST);
     });
 
-    // Test GET with offset
-    // TODO fix test
     test('/ - offset - 200 Success', async () => {
       const totalOffsetReports = 5;
       const res = await request
@@ -549,7 +547,6 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
-    // TODO fix test
     test('No queries is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
       const totalReports2 = await db.models.report.count();

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -539,7 +539,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
-    test.skip('No queries is OK', async () => {
+    test('No queries is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
       const res = await request
         .get('/api/reports')

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -290,14 +290,11 @@ describe('/reports/{REPORTID}', () => {
         .type('json')
         .expect(HTTP_STATUS.OK);
       const totalReports3 = await db.models.report.count();
-      console.log(totalReports2);
+      console.log(totalReports2, totalReports3);
       console.log('latest is here');
       checkReports(res.body.reports);
       expect(res.body.reports.length).toBe(3);
 
-      const totalReports3 = await db.models.report.count();
-      console.log(totalReports2);
-      console.log(totalReports3);
     }, LONGER_TIMEOUT);
 
     test('/ - offset - 400 Bad Request', async () => {
@@ -678,6 +675,7 @@ describe('/reports/{REPORTID}', () => {
     await db.models.report.destroy({where: {id: reportReviewed.id}, force: true});
     await db.models.report.destroy({where: {id: reportCompleted.id}, force: true});
     await db.models.report.destroy({where: {id: reportNonProduction.id}, force: true});
+    await db.models.report.destroy({where: {id: reportDualProj.id}, force: true});
   }, LONGER_TIMEOUT);
 });
 

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -1,6 +1,6 @@
 const HTTP_STATUS = require('http-status-codes');
 
-const {v4: uuidv4} = require('uuid');
+const {v4: uuidv4, stringify} = require('uuid');
 const supertest = require('supertest');
 const getPort = require('get-port');
 const db = require('../../../app/models');
@@ -98,7 +98,7 @@ describe('/reports/{REPORTID}', () => {
     });
     offsetTestProject = await db.models.project.create({
       where: {
-        name: `offset${uuidv4()}`
+        name: `offset${stringify(randomUuid)}`,
       }
     })
 

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -221,7 +221,7 @@ describe('/reports/{REPORTID}', () => {
 
   describe('GET', () => {
     // Test regular GET
-    test.skip('/ - 200 Success', async () => {
+    test('/ - 200 Success', async () => {
       const res = await request
         .get('/api/reports')
         .auth(username, password)
@@ -232,7 +232,7 @@ describe('/reports/{REPORTID}', () => {
     }, LONGER_TIMEOUT);
 
     // Test GET with paginated
-    test.skip('/ - paginated - 400 Bad Request', async () => {
+    test('/ - paginated - 400 Bad Request', async () => {
       await request
         .get('/api/reports?paginated=NOT_BOOLEAN')
         .auth(username, password)
@@ -240,7 +240,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.BAD_REQUEST);
     });
 
-    test.skip('/ - 200 GET non-production reports with "non-production access" group', async () => {
+    test('/ - 200 GET non-production reports with "non-production access" group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -255,7 +255,7 @@ describe('/reports/{REPORTID}', () => {
       expect(checkState(res.body.reports, 'nonproduction')).toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - 200 NOT GET non-production reports with non-authorized group', async () => {
+    test('/ - 200 NOT GET non-production reports with non-authorized group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -270,7 +270,7 @@ describe('/reports/{REPORTID}', () => {
       expect(checkState(res.body.reports, 'nonproduction')).not.toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - 200 GET report if have additional report permission', async () => {
+    test('/ - 200 GET report if have additional report permission', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -289,7 +289,7 @@ describe('/reports/{REPORTID}', () => {
       ).length > 0).toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - 200 GET unreviewed reports with "unreviewed access" group', async () => {
+    test('/ - 200 GET unreviewed reports with "unreviewed access" group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -304,7 +304,7 @@ describe('/reports/{REPORTID}', () => {
       expect(checkState(res.body.reports, 'ready')).toBeTruthy();
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - 200 NOT GET unreviewed reports with non-authorized group', async () => {
+    test('/ - 200 NOT GET unreviewed reports with non-authorized group', async () => {
       const res = await request
         .get('/api/reports')
         .query({
@@ -320,7 +320,7 @@ describe('/reports/{REPORTID}', () => {
     }, LONGER_TIMEOUT);
 
     // Test GET with limit
-    test.skip('/ - limit - 200 Success', async () => {
+    test('/ - limit - 200 Success', async () => {
       const res = await request
         .get('/api/reports?paginated=true&limit=4')
         .auth(username, password)
@@ -331,7 +331,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports.length).toBeLessThanOrEqual(4);
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - limit - 400 Bad Request', async () => {
+    test('/ - limit - 400 Bad Request', async () => {
       await request
         .get('/api/reports?paginated=true&limit=NOT_INTEGER')
         .auth(username, password)
@@ -339,7 +339,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.BAD_REQUEST);
     });
 
-    test.skip('/ - offset - 200 Success', async () => {
+    test('/ - offset - 200 Success', async () => {
       const totalOffsetReports = 5;
       const res = await request
         .get(`/api/reports?project=${offsetTestProject.name}&paginated=true&offset=${totalOffsetReports - 3}`)
@@ -351,7 +351,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports.length).toBe(3);
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - offset - 400 Bad Request', async () => {
+    test('/ - offset - 400 Bad Request', async () => {
       await request
         .get('/api/reports?paginated=true&offset=NOT_INTEGER')
         .auth(username, password)
@@ -360,7 +360,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with sort
-    test.skip('/ - sort - 200 Success', async () => {
+    test('/ - sort - 200 Success', async () => {
       const res = await request
         .get('/api/reports?sort=patientId:desc')
         .auth(username, password)
@@ -371,7 +371,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports[0].patientId).toEqual(res.body.reports[1].patientId);
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - sort - 400 Bad Request', async () => {
+    test('/ - sort - 400 Bad Request', async () => {
       await request
         .get('/api/reports?sort=INVALID_FIELD:desc')
         .auth(username, password)
@@ -380,7 +380,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with project
-    test.skip('/ - project - 200 Success', async () => {
+    test('/ - project - 200 Success', async () => {
       const res = await request
         .get('/api/reports?project=TEST')
         .auth(username, password)
@@ -396,7 +396,7 @@ describe('/reports/{REPORTID}', () => {
       ]));
     });
 
-    test.skip('/ - project - 403 Forbidden', async () => {
+    test('/ - project - 403 Forbidden', async () => {
       await request
         .get('/api/reports?project=SUPER-SECURE')
         .auth(username, password)
@@ -405,7 +405,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with states
-    test.skip('/ - states - 200 Success', async () => {
+    test('/ - states - 200 Success', async () => {
       const res = await request
         .get('/api/reports?states=ready')
         .auth(username, password)
@@ -419,7 +419,7 @@ describe('/reports/{REPORTID}', () => {
       ]));
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - states - 400 Bad Request', async () => {
+    test('/ - states - 400 Bad Request', async () => {
       await request
         .get('/api/reports?states=INVALID_STATE')
         .auth(username, password)
@@ -428,7 +428,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with role
-    test.skip('/ - role - 200 Success', async () => {
+    test('/ - role - 200 Success', async () => {
       const res = await request
         .get('/api/reports?role=clinician')
         .auth(username, password)
@@ -440,7 +440,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body.reports).toEqual([]);
     }, LONGER_TIMEOUT);
 
-    test.skip('/ - role - 400 Bad Request', async () => {
+    test('/ - role - 400 Bad Request', async () => {
       await request
         .get('/api/reports?role=INVALID_ROLE')
         .auth(username, password)
@@ -449,7 +449,7 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with search text
-    test.skip('/ - search text - 200 Success', async () => {
+    test('/ - search text - 200 Success', async () => {
       const res = await request
         .get('/api/reports?searchText=UPLOADPAT01')
         .auth(username, password)
@@ -463,7 +463,7 @@ describe('/reports/{REPORTID}', () => {
       ]));
     }, LONGER_TIMEOUT);
 
-    test.skip('fetches known ident ok', async () => {
+    test('fetches known ident ok', async () => {
       const res = await request
         .get(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -473,7 +473,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test.skip('fetches additional project permission ok', async () => {
+    test('fetches additional project permission ok', async () => {
       const res = await request
         .get(`/api/reports/${reportDualProj.ident}`)
         .query({
@@ -487,7 +487,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test.skip('fetches non-production ident with group OK', async () => {
+    test('fetches non-production ident with group OK', async () => {
       const res = await request
         .get(`/api/reports/${reportNonProduction.ident}`)
         .query({
@@ -501,7 +501,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test.skip('error on non-production ident with wrong group', async () => {
+    test('error on non-production ident with wrong group', async () => {
       await request
         .get(`/api/reports/${reportNonProduction.ident}`)
         .query({
@@ -513,7 +513,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
-    test.skip('fetches unreviewed ident with group OK', async () => {
+    test('fetches unreviewed ident with group OK', async () => {
       const res = await request
         .get(`/api/reports/${reportReady.ident}`)
         .query({
@@ -527,7 +527,7 @@ describe('/reports/{REPORTID}', () => {
       checkReport(res.body);
     });
 
-    test.skip('error on unreviewed ident with wrong group', async () => {
+    test('error on unreviewed ident with wrong group', async () => {
       await request
         .get(`/api/reports/${reportReady.ident}`)
         .query({
@@ -558,7 +558,7 @@ describe('/reports/{REPORTID}', () => {
       expect(allPresent).toBeTruthy();
     });
 
-    test.skip('State querying is OK', async () => {
+    test('State querying is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
       const res = await request
         .get('/api/reports')
@@ -572,7 +572,7 @@ describe('/reports/{REPORTID}', () => {
       });
     });
 
-    test.skip('Multiple queries is OK', async () => {
+    test('Multiple queries is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
       const res = await request
         .get('/api/reports')
@@ -592,7 +592,7 @@ describe('/reports/{REPORTID}', () => {
       });
     });
 
-    test.skip('error on non-existant ident', async () => {
+    test('error on non-existant ident', async () => {
       await request
         .get(`/api/reports/${randomUuid}`)
         .auth(username, password)
@@ -602,7 +602,7 @@ describe('/reports/{REPORTID}', () => {
   });
 
   describe('PUT', () => {
-    test.skip('state updated to ready when reviewed OK', async () => {
+    test('state updated to ready when reviewed OK', async () => {
       const res = await request
         .put(`/api/reports/${reportReviewed.ident}`)
         .auth(username, password)
@@ -616,7 +616,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('state', 'ready');
     });
 
-    test.skip('state NOT updated to ready when NOT reviewed OK', async () => {
+    test('state NOT updated to ready when NOT reviewed OK', async () => {
       const res = await request
         .put(`/api/reports/${reportCompleted.ident}`)
         .auth(username, password)
@@ -630,7 +630,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('state', 'completed');
     });
 
-    test.skip('tumour content update OK', async () => {
+    test('tumour content update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -644,7 +644,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('tumourContent', 23.2);
     });
 
-    test.skip('completed report update OK', async () => {
+    test('completed report update OK', async () => {
       const res = await request
         .put(`/api/reports/${reportCompleted.ident}`)
         .auth(username, password)
@@ -658,7 +658,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('tumourContent', 23.2);
     });
 
-    test.skip('completed report update FORBIDDEN', async () => {
+    test('completed report update FORBIDDEN', async () => {
       await request
         .put(`/api/reports/${reportCompleted.ident}`)
         .query({
@@ -673,7 +673,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
-    test.skip('M1M2 Score update OK', async () => {
+    test('M1M2 Score update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -687,7 +687,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('m1m2Score', 98.5);
     });
 
-    test.skip('ploidy update OK', async () => {
+    test('ploidy update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -701,7 +701,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('ploidy', 'triploid');
     });
 
-    test.skip('subtyping update OK', async () => {
+    test('subtyping update OK', async () => {
       const res = await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)
@@ -715,7 +715,7 @@ describe('/reports/{REPORTID}', () => {
       expect(res.body).toHaveProperty('subtyping', 'ER positive');
     });
 
-    test.skip('error on unexpected value', async () => {
+    test('error on unexpected value', async () => {
       await request
         .put(`/api/reports/${report.ident}`)
         .auth(username, password)

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -1,6 +1,6 @@
 const HTTP_STATUS = require('http-status-codes');
 
-const {v4: uuidv4, stringify} = require('uuid');
+const {v4: uuidv4} = require('uuid');
 const supertest = require('supertest');
 const getPort = require('get-port');
 const db = require('../../../app/models');
@@ -74,7 +74,6 @@ describe('/reports/{REPORTID}', () => {
   let reportReviewed;
   let reportCompleted;
   let reportNonProduction;
-  let totalReports;
   let report2;
   let reportReady2;
   let reportReviewed2;
@@ -96,7 +95,7 @@ describe('/reports/{REPORTID}', () => {
         name: 'TEST2',
       },
     });
-    offsetTestProject = await db.models.project.create({name: `offset${randomUuid.toString()}`})
+    offsetTestProject = await db.models.project.create({name: `offset${randomUuid.toString()}`});
 
     report = await db.models.report.create({
       templateId: template.id,
@@ -218,8 +217,6 @@ describe('/reports/{REPORTID}', () => {
       reportId: reportCompleted2.id,
       project_id: offsetTestProject.id,
     });
-
-    totalReports = await db.models.report.count();
   }, LONGER_TIMEOUT);
 
   describe('GET', () => {
@@ -352,7 +349,6 @@ describe('/reports/{REPORTID}', () => {
 
       checkReports(res.body.reports);
       expect(res.body.reports.length).toBe(3);
-
     }, LONGER_TIMEOUT);
 
     test('/ - offset - 400 Bad Request', async () => {
@@ -546,7 +542,7 @@ describe('/reports/{REPORTID}', () => {
     test.skip('No queries is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
       const res = await request
-        .get(`/api/reports`)
+        .get('/api/reports')
         .auth(username, password)
         .type('json')
         .expect(HTTP_STATUS.OK);
@@ -554,15 +550,14 @@ describe('/reports/{REPORTID}', () => {
       // when multiple report-generating test modules are running simultaneously
       // the full content of res.body can't be guaranteed; restrict checks to
       // tests created for this module
-      const expectedReports = [report,reportReady,reportReviewed,reportCompleted,reportNonProduction,report2,reportReady2,reportReviewed2,reportCompleted2,reportNonProduction2,reportDualProj]
+      const expectedReports = [report, reportReady, reportReviewed, reportCompleted, reportNonProduction, report2, reportReady2, reportReviewed2, reportCompleted2, reportNonProduction2, reportDualProj];
       expect(res.body.total).toBeGreaterThanOrEqual(expectedReports.length);
 
-      const expectedIds = (expectedReports).map((elem)=> {return elem.id});
-      const foundIds = (res.body).map((elem)=> {return elem.id});
+      const expectedIds = (expectedReports).map((elem) => {return elem.id;});
+      const foundIds = (res.body).map((elem) => {return elem.id;});
 
-      const allPresent = expectedIds.every(elem => foundIds.includes(elem));
-      expect(allPresent).to.be.true;
-
+      const allPresent = expectedIds.every((elem) => {return foundIds.includes(elem);});
+      expect(allPresent).toBeTruthy();
     });
 
     test('State querying is OK', async () => {

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -289,7 +289,9 @@ describe('/reports/{REPORTID}', () => {
         .auth(username, password)
         .type('json')
         .expect(HTTP_STATUS.OK);
-
+      const totalReports3 = await db.models.report.count();
+      console.log(totalReports2);
+      console.log('latest is here');
       checkReports(res.body.reports);
       expect(res.body.reports.length).toBe(3);
 

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -281,9 +281,11 @@ describe('/reports/{REPORTID}', () => {
     });
 
     // Test GET with offset
+    // TODO fix test
     test('/ - offset - 200 Success', async () => {
+      const totalReports2 = await db.models.report.count();
       const res = await request
-        .get(`/api/reports?paginated=true&offset=${totalReports - 3}`)
+        .get(`/api/reports?paginated=true&offset=${totalReports2 - 3}`)
         .auth(username, password)
         .type('json')
         .expect(HTTP_STATUS.OK);
@@ -480,8 +482,10 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
+    // TODO fix test
     test('No queries is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
+      const totalReports2 = await db.models.report.count();
       const res = await request
         .get('/api/reports')
         .auth(username, password)
@@ -489,7 +493,7 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.OK);
 
       // Check if the number of reports returned by api is the same as db
-      expect(res.body.total).toEqual(totalReports);
+      expect(res.body.total).toEqual(totalReports2);
     });
 
     test('State querying is OK', async () => {

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -292,6 +292,10 @@ describe('/reports/{REPORTID}', () => {
 
       checkReports(res.body.reports);
       expect(res.body.reports.length).toBe(3);
+
+      const totalReports3 = await db.models.report.count();
+      console.log(totalReports2);
+      console.log(totalReports3);
     }, LONGER_TIMEOUT);
 
     test('/ - offset - 400 Bad Request', async () => {

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -543,17 +543,26 @@ describe('/reports/{REPORTID}', () => {
         .expect(HTTP_STATUS.FORBIDDEN);
     });
 
-    test('No queries is OK', async () => {
+    test.skip('No queries is OK', async () => {
       // TODO: Add checks when https://www.bcgsc.ca/jira/browse/DEVSU-1273 is done
-      const totalReports2 = await db.models.report.count();
       const res = await request
-        .get('/api/reports')
+        .get(`/api/reports`)
         .auth(username, password)
         .type('json')
         .expect(HTTP_STATUS.OK);
 
-      // Check if the number of reports returned by api is the same as db
-      expect(res.body.total).toEqual(totalReports2);
+      // when multiple report-generating test modules are running simultaneously
+      // the full content of res.body can't be guaranteed; restrict checks to
+      // tests created for this module
+      const expectedReports = [report,reportReady,reportReviewed,reportCompleted,reportNonProduction,report2,reportReady2,reportReviewed2,reportCompleted2,reportNonProduction2,reportDualProj]
+      expect(res.body.total).toBeGreaterThanOrEqual(expectedReports.length);
+
+      const expectedIds = (expectedReports).map((elem)=> {return elem.id});
+      const foundIds = (res.body).map((elem)=> {return elem.id});
+
+      const allPresent = expectedIds.every(elem => foundIds.includes(elem));
+      expect(allPresent).to.be.true;
+
     });
 
     test('State querying is OK', async () => {

--- a/test/routes/report/report.test.js
+++ b/test/routes/report/report.test.js
@@ -83,7 +83,6 @@ describe('/reports/{REPORTID}', () => {
 
   beforeAll(async () => {
     // Get genomic template
-    console.log('check here 86');
     const template = await db.models.template.findOne({where: {name: 'genomic'}});
     // Create Report and associate projects
     project = await db.models.project.findOne({
@@ -97,7 +96,6 @@ describe('/reports/{REPORTID}', () => {
       },
     });
     offsetTestProject = await db.models.project.create({name: `offset${randomUuid.toString()}`});
-    console.log('check here 100');
 
     report = await db.models.report.create({
       templateId: template.id,
@@ -119,7 +117,6 @@ describe('/reports/{REPORTID}', () => {
       reportId: reportReady.id,
       project_id: project.id,
     });
-    console.log('check here 122');
 
     reportNonProduction = await db.models.report.create({
       templateId: template.id,
@@ -165,7 +162,6 @@ describe('/reports/{REPORTID}', () => {
       project_id: project2.id,
       additionalProject: true,
     });
-    console.log('check here 168');
 
     // create a second set of reports for use in the offset test, which relies on
     // a predictable set of reports in the db which means using a specific project
@@ -202,7 +198,6 @@ describe('/reports/{REPORTID}', () => {
       project_id: offsetTestProject.id,
     });
 
-    console.log('check here 205');
     reportReviewed2 = await db.models.report.create({
       templateId: template.id,
       patientId: mockReportData.patientId,
@@ -222,8 +217,6 @@ describe('/reports/{REPORTID}', () => {
       reportId: reportCompleted2.id,
       project_id: offsetTestProject.id,
     });
-    console.log('check here 224');
-
   }, LONGER_TIMEOUT);
 
   describe('GET', () => {
@@ -559,10 +552,8 @@ describe('/reports/{REPORTID}', () => {
       // tests created for this module
       const expectedReports = [report, reportReady, reportReviewed, reportCompleted, reportNonProduction, report2, reportReady2, reportReviewed2, reportCompleted2, reportNonProduction2, reportDualProj];
       expect(res.body.total).toBeGreaterThanOrEqual(expectedReports.length);
-
       const expectedIds = (expectedReports).map((elem) => {return elem.ident;});
       const foundIds = (res.body.reports).map((elem) => {return elem.ident;});
-
       const allPresent = expectedIds.every((elem) => {return foundIds.includes(elem);});
       expect(allPresent).toBeTruthy();
     });

--- a/test/routes/report/therapeuticTargets.test.js
+++ b/test/routes/report/therapeuticTargets.test.js
@@ -444,7 +444,7 @@ describe('/therapeutic-targets', () => {
     // Delete newly created report and all of it's components
     // indirectly by force deleting the report
     await db.models.report.destroy({where: {ident: report2.ident}, force: true});
-    return db.models.report.destroy({where: {ident: report.ident}, force: true});
+    await db.models.report.destroy({where: {ident: report.ident}, force: true});
   });
 });
 

--- a/test/routes/report/therapeuticTargets.test.js
+++ b/test/routes/report/therapeuticTargets.test.js
@@ -422,7 +422,7 @@ describe('/therapeutic-targets', () => {
   afterAll(async () => {
     // Delete newly created report and all of it's components
     // indirectly by force deleting the report
-    await db.models.report.destroy({where: {ident: report.ident}, force: true});
+    return db.models.report.destroy({where: {ident: report.ident}, force: true});
   });
 });
 

--- a/test/routes/report/therapeuticTargets.test.js
+++ b/test/routes/report/therapeuticTargets.test.js
@@ -99,7 +99,7 @@ describe('/therapeutic-targets', () => {
     }
   });
 
-  describe('POST (create)', () => {
+  describe.skip('POST (create)', () => {
     test('create new with valid gene input', async () => {
       const {body: record} = await request
         .post(`/api/reports/${report.ident}/therapeutic-targets`)
@@ -150,10 +150,12 @@ describe('/therapeutic-targets', () => {
       // create a new therapeutic target
       ({dataValues: originalGene} = await db.models.therapeuticTarget.create({
         ...FAKE_TARGET,
+        rank: 0,
         reportId: report.id,
       }));
       ({dataValues: originalSignature} = await db.models.therapeuticTarget.create({
         ...FAKE_SIGNATURE_TARGET,
+        rank: 1,
         reportId: report.id,
       }));
       geneUrl = `/api/reports/${report.ident}/therapeutic-targets/${originalGene.ident}`;
@@ -274,7 +276,7 @@ describe('/therapeutic-targets', () => {
         const {body: record} = await request
           .put(signatureUrl)
           .auth(username, password)
-          .send({gsignature: 'SAS'})
+          .send({signature: 'SAS'})
           .type('json')
           .expect(HTTP_STATUS.OK);
 
@@ -325,7 +327,7 @@ describe('/therapeutic-targets', () => {
           // create a new therapeutic target
           ({dataValues: newTarget} = await db.models.therapeuticTarget.create({
             ...FAKE_TARGET,
-            rank: 1,
+            rank: 2,
             reportId: report.id,
           }));
 
@@ -391,7 +393,7 @@ describe('/therapeutic-targets', () => {
         // Create second record
         const newTarget = await db.models.therapeuticTarget.create({
           ...FAKE_TARGET,
-          rank: 1,
+          rank: 3,
           reportId: report.id,
         });
 
@@ -407,7 +409,7 @@ describe('/therapeutic-targets', () => {
         });
 
         expect(Array.isArray(result)).toBe(true);
-        expect(result.length).toBe(1);
+        expect(result.length).toBe(2); // originalGene and originalSignature
 
         const [entry] = result;
 

--- a/test/routes/report/therapeuticTargets.test.js
+++ b/test/routes/report/therapeuticTargets.test.js
@@ -25,6 +25,17 @@ const FAKE_TARGET = {
   iprEvidenceLevel: 'IPR-A',
 };
 
+const FAKE_SIGNATURE_TARGET = {
+  type: 'therapeutic',
+  variant: 'p.G12D',
+  signature: 'SBS',
+  signatureGraphkbId: '#4:6',
+  context: 'resistance',
+  therapy: 'EGFR inhibitors',
+  evidenceLevel: 'OncoKB 1',
+  iprEvidenceLevel: 'IPR-A',
+};
+
 let server;
 let request;
 
@@ -266,9 +277,11 @@ describe('/therapeutic-targets', () => {
   });
 
   afterAll(async () => {
+    console.log('made it into after all');
     // Delete newly created report and all of it's components
     // indirectly by force deleting the report
-    return db.models.report.destroy({where: {ident: report.ident}, force: true});
+    await db.models.report.destroy({where: {ident: report.ident}, force: true});
+    console.dir('huh');
   });
 });
 

--- a/test/routes/report/therapeuticTargets.test.js
+++ b/test/routes/report/therapeuticTargets.test.js
@@ -99,7 +99,7 @@ describe('/therapeutic-targets', () => {
     }
   });
 
-  describe.skip('POST (create)', () => {
+  describe('POST (create)', () => {
     test('create new with valid gene input', async () => {
       const {body: record} = await request
         .post(`/api/reports/${report.ident}/therapeutic-targets`)


### PR DESCRIPTION
Adds signature to graphkb query endpoints.
Adds signature and signatureGraphkbId to reports_therapeutic_targets table. 
Since signature is an alternative to gene, updates put and post endpoints to make sure the record contains only either gene or signature data. 