### PR TITLE
Feat/devsu 2285 add permissions for managers

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -21,6 +21,8 @@ if (ENV === 'production') {
 
 const DEFAULT_TEST_USER = 'ipr-bamboo-admin';
 const DEFAULT_EMAIL_ADDRESS = 'PORIReportUpdates';
+const DEFAULT_TEST_MANAGER_USER = 'ipr-bamboo-manager';
+const DEFAULT_TEST_BIOINFORMATICIAN_USER = 'ipr-bamboo-bioinformatician';
 
 const DEFAULTS = {
   env: ENV,
@@ -46,6 +48,9 @@ const DEFAULTS = {
   },
   testing: {
     username: DEFAULT_TEST_USER,
+    managerUsername: DEFAULT_TEST_MANAGER_USER,
+    bioinformaticianUsername: DEFAULT_TEST_BIOINFORMATICIAN_USER,
+
   },
   email: {
     email: DEFAULT_EMAIL_ADDRESS,
@@ -141,6 +146,12 @@ const CONFIG = nconf
     },
     'testing.username': {
       alias: 'testing:username',
+    },
+    'testing.bioinformaticianUsername': {
+      alias: 'testing:bioinformaticianUsername',
+    },
+    'testing.managerUsername': {
+      alias: 'testing:managerUsername',
     },
     'email.email': {
       alias: 'email.email',

--- a/app/libs/helperFunctions.js
+++ b/app/libs/helperFunctions.js
@@ -67,8 +67,6 @@ const sanitizeHtml = (html) => {
  * @returns {boolean} - Returns a boolean indicating if the user is an admin
  */
 const isAdmin = (user) => {
-  console.log('in isAdmin');
-  console.dir(user.groups);
   return user.groups?.some((group) => {
     return group.name.toLowerCase() === 'admin';
   });

--- a/app/libs/helperFunctions.js
+++ b/app/libs/helperFunctions.js
@@ -73,6 +73,18 @@ const isAdmin = (user) => {
 };
 
 /**
+ * Checks if user is an admin
+ *
+ * @param {object} user - Sequelize user model
+ * @returns {boolean} - Returns a boolean indicating if the user is an admin
+ */
+const isManager = (user) => {
+  return user.groups.some((group) => {
+    return group.name.toLowerCase() === 'admin' || group.name.toLowerCase() === 'manager';
+  });
+};
+
+/**
  * Checks if user has access to non-prod repots
  *
  * @param {object} user - Sequelize user model
@@ -173,6 +185,7 @@ module.exports = {
   sanitizeHtml,
   getUserProjects,
   isAdmin,
+  isManager,
   hasAccess,
   hasAccessToNonProdReports,
   hasAccessToUnreviewedReports,

--- a/app/libs/helperFunctions.js
+++ b/app/libs/helperFunctions.js
@@ -67,7 +67,9 @@ const sanitizeHtml = (html) => {
  * @returns {boolean} - Returns a boolean indicating if the user is an admin
  */
 const isAdmin = (user) => {
-  return user.groups.some((group) => {
+  console.log('in isAdmin');
+  console.dir(user.groups);
+  return user.groups?.some((group) => {
     return group.name.toLowerCase() === 'admin';
   });
 };
@@ -79,7 +81,7 @@ const isAdmin = (user) => {
  * @returns {boolean} - Returns a boolean indicating if the user is an admin
  */
 const isManager = (user) => {
-  return user.groups.some((group) => {
+  return user.groups?.some((group) => {
     return group.name.toLowerCase() === 'admin' || group.name.toLowerCase() === 'manager';
   });
 };
@@ -91,7 +93,7 @@ const isManager = (user) => {
  * @returns {boolean} - Returns a boolean indicating if the user has access to non-prod reports
  */
 const hasAccessToNonProdReports = (user) => {
-  return user.groups.some((group) => {
+  return user.groups?.some((group) => {
     return group.name.toLowerCase() === 'admin'
     || group.name.toLowerCase() === 'manager'
     || group.name.toLowerCase() === 'non-production access';
@@ -105,7 +107,7 @@ const hasAccessToNonProdReports = (user) => {
  * @returns {boolean} - Returns a boolean indicating if the user has access to unreviewed reports
  */
 const hasAccessToUnreviewedReports = (user) => {
-  return user.groups.some((group) => {
+  return user.groups?.some((group) => {
     return group.name.toLowerCase() === 'admin'
     || group.name.toLowerCase() === 'manager'
     || group.name.toLowerCase() === 'unreviewed access';
@@ -119,7 +121,7 @@ const hasAccessToUnreviewedReports = (user) => {
  * @returns {boolean} - Returns a boolean indicating if the user has access to germline reports
  */
 const hasAccessToGermlineReports = (user) => {
-  return user.groups.some((group) => {
+  return user.groups?.some((group) => {
     return group.name.toLowerCase() === 'admin'
     || group.name.toLowerCase() === 'manager'
     || group.name.toLowerCase() === 'germline access';
@@ -135,7 +137,7 @@ const hasAccessToGermlineReports = (user) => {
  * @returns {boolean} - Returns true if user belongs to one of the access groups
  */
 const hasAccess = (user, accessGroups) => {
-  return user.groups.some((group) => {
+  return user.groups?.some((group) => {
     return accessGroups.includes(group.name.toLowerCase());
   });
 };

--- a/app/middleware/acl.js
+++ b/app/middleware/acl.js
@@ -11,13 +11,18 @@ const SPECIAL_CASES = [
   {
     path: pathToRegexp('/api/user'),
     GET: [{name: 'admin'}, {name: 'manager'}],
+    POST: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/user/:user'),
+    GET: [{name: 'admin'}, {name: 'manager'}],
+    PUT: [{name: 'admin'}, {name: 'manager'}],
     DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/user/group/:group/member'),
+    GET: [{name: 'admin'}, {name: 'manager'}],
+    POST: [{name: 'admin'}, {name: 'manager'}],
     DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
   {
@@ -30,6 +35,7 @@ const SPECIAL_CASES = [
   },
   {
     path: pathToRegexp('/api/template'),
+    GET: [{name: 'admin'}, {name: 'manager'}],
     POST: [{name: 'admin'}, {name: 'manager'}],
   },
   {
@@ -39,16 +45,18 @@ const SPECIAL_CASES = [
   },
   {
     path: pathToRegexp('/api/project'),
-    POST: [{name: 'admin'}, {name: 'manager'}],
+    POST: [{name: 'admin'}],
   },
   {
     path: pathToRegexp('/api/project/:project'),
-    PUT: [{name: 'admin'}, {name: 'manager'}],
-    DELETE: [{name: 'admin'}, {name: 'manager'}],
+    PUT: [{name: 'admin'}],
+    DELETE: [{name: 'admin'}],
   },
   {
     path: pathToRegexp('/api/project/:project/user'),
     GET: [{name: 'admin'}, {name: 'manager'}],
+    POST: [{name: 'admin'}, {name: 'manager'}],
+    DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/project/:project/reports'),

--- a/app/middleware/acl.js
+++ b/app/middleware/acl.js
@@ -1,7 +1,7 @@
 const {FORBIDDEN} = require('http-status-codes');
 const {pathToRegexp} = require('path-to-regexp');
 const {
-  isAdmin, isIntersectionBy, hasAccess, hasMasterAccess, projectAccess, hasAccessToGermlineReports,
+  isAdmin, isManager, isIntersectionBy, hasAccess, hasMasterAccess, projectAccess, hasAccessToGermlineReports,
 } = require('../libs/helperFunctions');
 const {MASTER_REPORT_ACCESS, UPDATE_METHODS} = require('../constants');
 const db = require('../models');
@@ -10,11 +10,11 @@ const logger = require('../log');
 const SPECIAL_CASES = [
   {
     path: pathToRegexp('/api/user'),
-    GET: [{name: 'admin'}],
+    GET: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/user/:user'),
-    DELETE: [{name: 'admin'}],
+    DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/reports'),
@@ -80,7 +80,7 @@ module.exports = async (req, res, next) => {
   // Get route
   const [route] = req.originalUrl.split('?');
 
-  if (!hasAccessToGermlineReports(req.user) && route.includes('/germline-small-mutation-reports')) {
+  if (!hasAccessToGermlineReports(req.user) && !isManager(req.user) && route.includes('/germline-small-mutation-reports')) {
     logger.error('User does not have germline access');
     return res.status(
       FORBIDDEN,

--- a/app/middleware/acl.js
+++ b/app/middleware/acl.js
@@ -26,21 +26,21 @@ const SPECIAL_CASES = [
   },
   {
     path: pathToRegexp('/api/template'),
-    POST: [{name: 'admin'}],
+    POST: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/template/:template'),
-    PUT: [{name: 'admin'}],
-    DELETE: [{name: 'admin'}],
+    PUT: [{name: 'admin'}, {name: 'manager'}],
+    DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/project'),
-    POST: [{name: 'admin'}],
+    POST: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/project/:project'),
-    PUT: [{name: 'admin'}],
-    DELETE: [{name: 'admin'}],
+    PUT: [{name: 'admin'}, {name: 'manager'}],
+    DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
   {
     path: pathToRegexp('/api/project/:project/user'),

--- a/app/middleware/acl.js
+++ b/app/middleware/acl.js
@@ -34,7 +34,7 @@ const SPECIAL_CASES = [
     POST: ['*'],
   },
   {
-    path: pathToRegexp('/api/template'),
+    path: pathToRegexp('/api/templates'),
     GET: [{name: 'admin'}, {name: 'manager'}],
     POST: [{name: 'admin'}, {name: 'manager'}],
   },
@@ -61,6 +61,8 @@ const SPECIAL_CASES = [
   {
     path: pathToRegexp('/api/project/:project/reports'),
     GET: [{name: 'admin'}, {name: 'manager'}],
+    POST: [{name: 'admin'}],
+    DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
 ];
 

--- a/app/middleware/acl.js
+++ b/app/middleware/acl.js
@@ -17,6 +17,10 @@ const SPECIAL_CASES = [
     DELETE: [{name: 'admin'}, {name: 'manager'}],
   },
   {
+    path: pathToRegexp('/api/user/group/:group/member'),
+    DELETE: [{name: 'admin'}, {name: 'manager'}],
+  },
+  {
     path: pathToRegexp('/api/reports'),
     POST: ['*'],
   },

--- a/app/routes/appendix/appendix.js
+++ b/app/routes/appendix/appendix.js
@@ -6,7 +6,7 @@ const router = express.Router({mergeParams: true});
 
 const db = require('../../models');
 const logger = require('../../log');
-const {sanitizeHtml} = require('../../libs/helperFunctions');
+const {sanitizeHtml, isAdmin} = require('../../libs/helperFunctions');
 
 const schemaGenerator = require('../../schemas/schemaGenerator');
 const validateAgainstSchema = require('../../libs/validateAgainstSchema');
@@ -67,6 +67,14 @@ router.route('/')
       return res.status(HTTP_STATUS.BAD_REQUEST).json({error: {message}});
     }
 
+    const userProjects = (req.user.projects).map((elem) => {return elem.name;});
+    // if user is manager and does not have the project id for this appendix
+    if (!isAdmin(req.user) && !userProjects.includes(req.templateAppendix.project?.name)) {
+      const msg = 'Non-admin user can not edit template text without project membership';
+      logger.error(msg);
+      return res.status(HTTP_STATUS.FORBIDDEN).json({error: {msg}});
+    }
+
     // Sanitize text
     if (req.body.text) {
       req.body.text = sanitizeHtml(req.body.text);
@@ -85,6 +93,14 @@ router.route('/')
   })
   .delete(async (req, res) => {
     // Soft delete template appendix
+    const userProjects = (req.user.projects).map((elem) => {return elem.name;});
+    // if user is manager and does not have the project id for this appendix
+    if (!isAdmin(req.user) && !userProjects.includes(req.templateAppendix.project?.name)) {
+      const msg = 'Non-admin user can not delete template text without project membership';
+      logger.error(msg);
+      return res.status(HTTP_STATUS.FORBIDDEN).json({error: {msg}});
+    }
+
     try {
       await req.templateAppendix.destroy();
       return res.status(HTTP_STATUS.NO_CONTENT).send();

--- a/app/routes/project/project.js
+++ b/app/routes/project/project.js
@@ -24,6 +24,8 @@ const updateSchema = schemaGenerator(db.models.project, {
 
 router.param('project', projectMiddleware);
 
+// TODO add manager/admin restrictions
+
 // Project routes
 router.route('/:project([A-z0-9-]{36})')
   .get(async (req, res) => {

--- a/app/routes/project/project.js
+++ b/app/routes/project/project.js
@@ -24,8 +24,6 @@ const updateSchema = schemaGenerator(db.models.project, {
 
 router.param('project', projectMiddleware);
 
-// TODO add manager/admin restrictions
-
 // Project routes
 router.route('/:project([A-z0-9-]{36})')
   .get(async (req, res) => {
@@ -110,7 +108,7 @@ router.route('/')
       const projects = await db.models.project.scope('public').findAll(opts);
       return res.json(projects);
     } catch (error) {
-      logger.error(`Error while trying to retrieve projects${error}`);
+      logger.error(`Error while trying to retrieve projects ${error}`);
       return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
         error: {message: 'Unable to retrieve projects'},
       });

--- a/app/routes/project/projectReports.js
+++ b/app/routes/project/projectReports.js
@@ -4,6 +4,8 @@ const express = require('express');
 const db = require('../../models');
 const logger = require('../../log');
 
+const {isAdmin} = require('../../libs/helperFunctions');
+
 const router = express.Router({mergeParams: true});
 
 // Report-project binding routes

--- a/app/routes/project/projectReports.js
+++ b/app/routes/project/projectReports.js
@@ -32,6 +32,12 @@ router.route('/')
       });
     }
 
+    if (!isAdmin(req.user) && !(req.user.projects).map((proj) => {return proj.name;}).includes(req.project.name)) {
+      const msg = 'User does not have permission to add reports to this group';
+      logger.error(msg);
+      return res.status(HTTP_STATUS.FORBIDDEN).json({error: {message: msg}});
+    }
+
     // Check for binding
     let binding;
     try {
@@ -91,6 +97,12 @@ router.route('/')
       return res.status(HTTP_STATUS.NOT_FOUND).json({
         error: {message: `Unable to find report ${req.body.report}`},
       });
+    }
+
+    if (!isAdmin(req.user) && !(req.user.projects).map((proj) => {return proj.name;}).includes(req.project.name)) {
+      const msg = 'User does not have permission to add this project from reports';
+      logger.error(msg);
+      return res.status(HTTP_STATUS.FORBIDDEN).json({error: {message: msg}});
     }
 
     let binding;

--- a/app/routes/project/projectUsers.js
+++ b/app/routes/project/projectUsers.js
@@ -4,6 +4,8 @@ const express = require('express');
 const db = require('../../models');
 const logger = require('../../log');
 
+const {isAdmin} = require('../../libs/helperFunctions');
+
 const router = express.Router({mergeParams: true});
 
 // User-project binding routes
@@ -28,6 +30,12 @@ router.route('/')
     if (!user) {
       logger.error(`Unable to find user ${req.body.user}`);
       return res.status(HTTP_STATUS.NOT_FOUND).json({error: {message: 'Unable to find user'}});
+    }
+
+    if (!isAdmin(req.user) && !(req.user.projects).map((proj) => {return proj.name;}).includes(req.project.name)) {
+      const msg = 'User does not have permission to add other users to this group';
+      logger.error(msg);
+      return res.status(HTTP_STATUS.FORBIDDEN).json({error: {message: msg}});
     }
 
     let binding;
@@ -88,6 +96,12 @@ router.route('/')
       return res.status(HTTP_STATUS.NOT_FOUND).json({
         error: {message: 'Unable to find the provided user'},
       });
+    }
+
+    if (!isAdmin(req.user) && !(req.user.projects).map((proj) => {return proj.name;}).includes(req.project.name)) {
+      const msg = 'User does not have permission to remove other users from this group';
+      logger.error(msg);
+      return res.status(HTTP_STATUS.FORBIDDEN).json({error: {message: msg}});
     }
 
     try {

--- a/app/routes/user/index.js
+++ b/app/routes/user/index.js
@@ -17,3 +17,5 @@ router.use('/group/:group/member', member);
 router.use('/settings', settings);
 
 module.exports = router;
+
+// TODO: add manager/admin restrictions

--- a/app/routes/user/member.js
+++ b/app/routes/user/member.js
@@ -5,7 +5,7 @@ const db = require('../../models');
 const logger = require('../../log');
 
 const router = express.Router({mergeParams: true});
-const {isAdmin, isManager} = require('../../libs/helperFunctions');
+const {isAdmin} = require('../../libs/helperFunctions');
 const schemaGenerator = require('../../schemas/schemaGenerator');
 const validateAgainstSchema = require('../../libs/validateAgainstSchema');
 const {BASE_EXCLUDE} = require('../../schemas/exclude');

--- a/app/routes/user/member.js
+++ b/app/routes/user/member.js
@@ -119,7 +119,7 @@ router.route('/')
       logger.error('User doesn\'t exist');
       return res.status(HTTP_STATUS.NOT_FOUND).json({error: {message: 'User doesn\'t exist'}});
     }
-    const subjectUserIsAdmin = isAdmin(user);
+
     const groupIsAdmin = req.group.name === 'admin';
 
     // TODO: add tests for these checks
@@ -128,6 +128,13 @@ router.route('/')
       logger.error(msg);
       return res.status(HTTP_STATUS.FORBIDDEN).json({error: {message: msg}});
     }
+
+    const adminGroup = await db.models.userGroup.findOne({
+      where: {name: 'admin'},
+    });
+    const subjectUserIsAdmin = await db.models.userGroupMember.findOne({
+      where: {group_id: adminGroup.id, user_id: user.id},
+    });
 
     if (!reqUserIsAdmin && subjectUserIsAdmin) {
       const msg = 'Non-admin user can not edit user groups of admin users';

--- a/app/routes/user/user.js
+++ b/app/routes/user/user.js
@@ -74,6 +74,8 @@ router.route('/:userByIdent([A-z0-9-]{36})')
     return res.json(req.userByIdent.view('public'));
   })
   .put(async (req, res) => {
+    // TODO make sure edited user isn't admin while
+    // editing user is not admin
     const manager = isManager(req.user);
 
     if (!manager && req.user.id !== req.userByIdent.id) {
@@ -124,6 +126,8 @@ router.route('/:userByIdent([A-z0-9-]{36})')
     }
   })
   .delete(async (req, res) => {
+    // TODO add check that user being deleted is not admin
+    // while deleted user is not admin
     try {
       await req.userByIdent.destroy();
       return res.status(HTTP_STATUS.NO_CONTENT).send();

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -45,6 +45,7 @@ module.exports = {
   setupFiles: [
     '<rootDir>/test/graphkb.mock.js',
     '<rootDir>/config/jest/jestSetup.js',
+    '<rootDir>/test/testSetup.js',
   ],
   testTimeout: 10000,
 };

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -45,6 +45,8 @@ module.exports = {
   setupFiles: [
     '<rootDir>/test/graphkb.mock.js',
     '<rootDir>/config/jest/jestSetup.js',
+  ],
+  globalSetup: [
     '<rootDir>/test/testSetup.js',
   ],
   testTimeout: 10000,

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -46,8 +46,6 @@ module.exports = {
     '<rootDir>/test/graphkb.mock.js',
     '<rootDir>/config/jest/jestSetup.js',
   ],
-  globalSetup: [
-    '<rootDir>/test/testSetup.js',
-  ],
+  globalSetup: '<rootDir>/test/testSetup.js',
   testTimeout: 10000,
 };

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -46,6 +46,8 @@ module.exports = {
     '<rootDir>/test/graphkb.mock.js',
     '<rootDir>/config/jest/jestSetup.js',
   ],
-  globalSetup: '<rootDir>/test/testSetup.js',
+  setupFilesAfterEnv: [
+    '<rootDir>/test/testSetup.js',
+  ],
   testTimeout: 10000,
 };

--- a/test/routes/project/project.test.js
+++ b/test/routes/project/project.test.js
@@ -229,8 +229,8 @@ describe('/project', () => {
     });
 
     afterEach(async () => {
-      return deleteTestProject.destroy({force: true});
-      return deleteTestProject2.destroy({force: true});
+      await deleteTestProject.destroy({force: true});
+      await deleteTestProject2.destroy({force: true});
     });
 
     test('/{project} - 204 Success', async () => {

--- a/test/routes/project/projectReports.test.js
+++ b/test/routes/project/projectReports.test.js
@@ -10,7 +10,6 @@ const {listen} = require('../../../app');
 
 CONFIG.set('env', 'test');
 const {username, password} = CONFIG.get('testing');
-
 const reportProperties = [
   'ident', 'createdAt', 'updatedAt', 'patientId', 'alternateIdentifier',
 ];
@@ -50,6 +49,8 @@ describe('/project/:project/reports', () => {
   let report02;
 
   beforeAll(async () => {
+    console.dir(CONFIG.get('testing');
+
     // Get genomic template
     const template = await db.models.template.findOne({where: {name: 'genomic'}});
 

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -48,10 +48,11 @@ beforeAll(async () => {
   });
   if (!managerUser) {
     managerUser = await db.models.user.create({
+      ident: uuidv4(),
       username: 'ipr-bamboo-manager',
-      email: 'dat@bcgsc.ca',
       firstname: 'ipr-bamboo-manager',
       lastname: 'ipr-bamboo-manager',
+      email: 'dat@bcgsc.ca',
     });
   }
   managerGroup = await db.models.userGroup.findOne({

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -81,7 +81,7 @@ beforeAll(async () => {
     where: {name: 'Bioinformatician'},
   });
   if (!bioinformaticianGroup) {
-    bioinformaticianUser = await db.models.userGroup.create({
+    bioinformaticianGroup = await db.models.userGroup.create({
       ident: uuidv4(),
       name: 'Bioinformatician',
     });

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -37,12 +37,15 @@ let server;
 let request;
 let managerUser;
 let managerGroup;
+let bioinformaticianUser;
+let bioinformaticianGroup;
 
 // Start API
 beforeAll(async () => {
   const port = await getPort({port: CONFIG.get('web:port')});
   server = await listen(port);
   request = supertest(server);
+
   managerUser = await db.models.user.findOne({
     where: {username: managerUsername},
   });
@@ -60,6 +63,25 @@ beforeAll(async () => {
   });
   await db.models.userGroupMember.findOrCreate({
     where: {user_id: managerUser.id, group_id: managerGroup.id},
+  });
+
+  bioinformaticianUser = await db.models.user.findOne({
+    where: {username: bioinformaticianUsername},
+  });
+  if (!bioinformaticianUser) {
+    bioinformaticianUser = await db.models.user.create({
+      ident: uuidv4(),
+      username: 'ipr-bamboo-bioinformatician',
+      firstName: 'ipr-bamboo-bioinformatician',
+      lastName: 'ipr-bamboo-bioinformatician',
+      email: 'dat@bcgsc.ca',
+    });
+  }
+  bioinformaticianGroup = await db.models.userGroup.findOne({
+    where: {name: 'Bioinformatician'},
+  });
+  await db.models.userGroupMember.findOrCreate({
+    where: {user_id: bioinformaticianUser.id, group_id: bioinformaticianGroup.id},
   });
 });
 

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -59,7 +59,7 @@ beforeAll(async () => {
     where: {name: 'manager'},
   });
   await db.models.userGroupMember.findOrCreate({
-    user_id: managerUser.id, group_id: managerGroup.id,
+    where: {user_id: managerUser.id, group_id: managerGroup.id},
   });
 });
 

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -36,7 +36,6 @@ const checkProjectUsers = (users) => {
 let server;
 let request;
 let managerUser;
-let bioinformaticianUser;
 
 // Start API
 beforeAll(async () => {
@@ -46,10 +45,6 @@ beforeAll(async () => {
 
   managerUser = await db.models.user.findOne({
     where: {username: managerUsername},
-  });
-
-  bioinformaticianUser = await db.models.user.findOne({
-    where: {username: bioinformaticianUsername},
   });
 });
 

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -36,9 +36,7 @@ const checkProjectUsers = (users) => {
 let server;
 let request;
 let managerUser;
-let managerGroup;
 let bioinformaticianUser;
-let bioinformaticianGroup;
 
 // Start API
 beforeAll(async () => {
@@ -49,45 +47,9 @@ beforeAll(async () => {
   managerUser = await db.models.user.findOne({
     where: {username: managerUsername},
   });
-  if (!managerUser) {
-    managerUser = await db.models.user.create({
-      ident: uuidv4(),
-      username: 'ipr-bamboo-manager',
-      firstName: 'ipr-bamboo-manager',
-      lastName: 'ipr-bamboo-manager',
-      email: 'dat@bcgsc.ca',
-    });
-  }
-  managerGroup = await db.models.userGroup.findOne({
-    where: {name: 'manager'},
-  });
-  await db.models.userGroupMember.findOrCreate({
-    where: {user_id: managerUser.id, group_id: managerGroup.id},
-  });
 
   bioinformaticianUser = await db.models.user.findOne({
     where: {username: bioinformaticianUsername},
-  });
-  if (!bioinformaticianUser) {
-    bioinformaticianUser = await db.models.user.create({
-      ident: uuidv4(),
-      username: 'ipr-bamboo-bioinformatician',
-      firstName: 'ipr-bamboo-bioinformatician',
-      lastName: 'ipr-bamboo-bioinformatician',
-      email: 'dat@bcgsc.ca',
-    });
-  }
-  bioinformaticianGroup = await db.models.userGroup.findOne({
-    where: {name: 'Bioinformatician'},
-  });
-  if (!bioinformaticianGroup) {
-    bioinformaticianGroup = await db.models.userGroup.create({
-      ident: uuidv4(),
-      name: 'Bioinformatician',
-    });
-  }
-  await db.models.userGroupMember.findOrCreate({
-    where: {user_id: bioinformaticianUser.id, group_id: bioinformaticianGroup.id},
   });
 });
 

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -80,6 +80,12 @@ beforeAll(async () => {
   bioinformaticianGroup = await db.models.userGroup.findOne({
     where: {name: 'Bioinformatician'},
   });
+  if (!bioinformaticianGroup) {
+    bioinformaticianUser = await db.models.userGroup.create({
+      ident: uuidv4(),
+      name: 'Bioinformatician',
+    });
+  }
   await db.models.userGroupMember.findOrCreate({
     where: {user_id: bioinformaticianUser.id, group_id: bioinformaticianGroup.id},
   });

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -35,12 +35,23 @@ const checkProjectUsers = (users) => {
 
 let server;
 let request;
+let managerUser;
+let managerGroup;
 
 // Start API
 beforeAll(async () => {
   const port = await getPort({port: CONFIG.get('web:port')});
   server = await listen(port);
   request = supertest(server);
+  managerUser = await db.models.user.findOne({
+    where: {username: managerUsername},
+  });
+  managerGroup = await db.models.userGroup.findOne({
+    where: {name: 'manager'},
+  });
+  await db.models.userGroupMember.findOrCreate({
+    user_id: managerUser.id, group_id: managerGroup.id,
+  });
 });
 
 // Tests for project user endpoints
@@ -51,7 +62,6 @@ describe('/project/:project/user', () => {
   let user01;
   let user02;
   let user03;
-  let managerUser;
   let managerProjectBinding;
 
   beforeAll(async () => {
@@ -63,9 +73,6 @@ describe('/project/:project/user', () => {
     // Create project
     project = await db.models.project.create({name: 'user-project-test01'});
     nonManagerProject = await db.models.project.create({name: 'user-project-test02'});
-    managerUser = await db.models.user.findOne({
-      where: {username: managerUsername},
-    });
     // Create users
     user01 = await db.models.user.create({
       ident: uuidv4(),

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -50,8 +50,8 @@ beforeAll(async () => {
     managerUser = await db.models.user.create({
       ident: uuidv4(),
       username: 'ipr-bamboo-manager',
-      firstname: 'ipr-bamboo-manager',
-      lastname: 'ipr-bamboo-manager',
+      firstName: 'ipr-bamboo-manager',
+      lastName: 'ipr-bamboo-manager',
       email: 'dat@bcgsc.ca',
     });
   }

--- a/test/routes/project/projectUsers.test.js
+++ b/test/routes/project/projectUsers.test.js
@@ -46,6 +46,14 @@ beforeAll(async () => {
   managerUser = await db.models.user.findOne({
     where: {username: managerUsername},
   });
+  if (!managerUser) {
+    managerUser = await db.models.user.create({
+      username: 'ipr-bamboo-manager',
+      email: 'dat@bcgsc.ca',
+      firstname: 'ipr-bamboo-manager',
+      lastname: 'ipr-bamboo-manager',
+    });
+  }
   managerGroup = await db.models.userGroup.findOne({
     where: {name: 'manager'},
   });

--- a/test/routes/template/template.test.js
+++ b/test/routes/template/template.test.js
@@ -371,7 +371,7 @@ describe('/templates', () => {
 
       checkTemplate(res.body);
       expect(res.body).toEqual(expect.objectContaining({
-        name: 'New Name',
+        name: 'New Name - by manager',
         organization: 'New Orgs',
         sections: ['therapeutic-targets', 'genes'],
         description: 'New Description',

--- a/test/routes/template/template.test.js
+++ b/test/routes/template/template.test.js
@@ -8,11 +8,11 @@ const CONFIG = require('../../../app/config');
 const {listen} = require('../../../app');
 
 CONFIG.set('env', 'test');
-const {username, password} = CONFIG.get('testing');
+const {username, managerUsername, bioinformaticianUsername, password} = CONFIG.get('testing');
 
 const LONGER_TIMEOUT = 50000;
 
-const BASE_URI = '/api/templates';
+const BASE_URI = '/api/templates'; // TODO; we're testing templates; acl said template; what is client using?
 
 let server;
 let request;
@@ -38,6 +38,16 @@ const UPLOAD_DATA = {
   ],
 };
 
+const UPLOAD_DATA_BY_MANAGER = {
+  name: 'Test Upload Template - manager',
+  organization: 'Test Upload Org',
+  description: 'Test Upload Description',
+  sections: [
+    'therapeutic-targets',
+    'structural-variants',
+  ],
+};
+
 const UPDATE_DATA = {
   name: 'Test Update Template',
   organization: 'Test Update Org',
@@ -48,8 +58,48 @@ const UPDATE_DATA = {
   ],
 };
 
+const UPDATE_DATA_BY_MANAGER = {
+  name: 'Test Update Template - manager',
+  organization: 'Test Update Org',
+  description: 'Test Update Description',
+  sections: [
+    'microbial',
+    'structural-variants',
+  ],
+};
+
+const UPDATE_DATA_BY_BIOINFORMATICIAN = {
+  name: 'Test Update Template - bioinformatician',
+  organization: 'Test Update Org',
+  description: 'Test Update Description',
+  sections: [
+    'microbial',
+    'structural-variants',
+  ],
+};
+
 const DELETE_DATA = {
   name: 'Test Delete Template',
+  organization: 'Test Delete Org',
+  description: 'Test Delete Description',
+  sections: [
+    'therapeutic-targets',
+    'structural-variants',
+  ],
+};
+
+const DELETE_DATA_BY_MANAGER = {
+  name: 'Test Delete Template - manager',
+  organization: 'Test Delete Org',
+  description: 'Test Delete Description',
+  sections: [
+    'therapeutic-targets',
+    'structural-variants',
+  ],
+};
+
+const DELETE_DATA_BY_BIOINFORMATICIAN = {
+  name: 'Test Delete Template - bioinf',
   organization: 'Test Delete Org',
   description: 'Test Delete Description',
   sections: [
@@ -180,6 +230,51 @@ describe('/templates', () => {
       await db.models.template.destroy({where: {ident: res.body.ident}, force: true});
     }, LONGER_TIMEOUT);
 
+    test('/ - 201 Created by manager', async () => {
+      const newImages = [];
+      const res = await request
+        .post(BASE_URI)
+        .attach('logo', 'test/testData/images/golden.jpg')
+        .attach('header', 'test/testData/images/golden.jpg')
+        .field('name', 'Test Upload Template - manager')
+        .field('organization', 'Test Upload Org')
+        .field('description', 'Test Upload Description')
+        .field('sections', 'therapeutic-targets')
+        .field('sections', 'structural-variants')
+        .auth(managerUsername, password)
+        .expect(HTTP_STATUS.CREATED);
+
+      checkTemplate(res.body);
+      expect(res.body).toEqual(expect.objectContaining(UPLOAD_DATA_BY_MANAGER));
+
+      expect(res.body.logoImage.ident).not.toBeNull();
+      newImages.push(res.body.logoImage.ident);
+      expect(res.body.headerImage.ident).not.toBeNull();
+      newImages.push(res.body.headerImage.ident);
+
+      // Check that record was created in the db
+      const result = await db.models.template.findOne({where: {ident: res.body.ident}});
+      expect(result).not.toBeNull();
+
+      // Delete template and images
+      await db.models.image.destroy({where: {ident: {[Op.in]: newImages}}, force: true});
+      await db.models.template.destroy({where: {ident: res.body.ident}, force: true});
+    }, LONGER_TIMEOUT);
+
+    test('/ - 403 Creating forbidden by bioinformatician', async () => {
+      await request
+        .post(BASE_URI)
+        .attach('logo', 'test/testData/images/golden.jpg')
+        .attach('header', 'test/testData/images/golden.jpg')
+        .field('name', 'Test Upload Template - bioinformatician')
+        .field('organization', 'Test Upload Org')
+        .field('description', 'Test Upload Description')
+        .field('sections', 'therapeutic-targets')
+        .field('sections', 'structural-variants')
+        .auth(bioinformaticianUsername, password)
+        .expect(HTTP_STATUS.FORBIDDEN);
+    }, LONGER_TIMEOUT);
+
     test('/ - name is required - 400 Bad Request', async () => {
       const {name, ...data} = UPLOAD_DATA;
       await request
@@ -212,13 +307,19 @@ describe('/templates', () => {
 
   describe('PUT', () => {
     let templateUpdate;
+    let templateUpdateManager;
+    let templateUpdateBioinf;
 
     beforeEach(async () => {
       templateUpdate = await db.models.template.create(UPDATE_DATA);
+      templateUpdateManager = await db.models.template.create(UPDATE_DATA_BY_MANAGER);
+      templateUpdateBioinf = await db.models.template.create(UPDATE_DATA_BY_BIOINFORMATICIAN);
     });
 
     afterEach(async () => {
       await db.models.template.destroy({where: {ident: templateUpdate.ident}, force: true});
+      await db.models.template.destroy({where: {ident: templateUpdateManager.ident}, force: true});
+      await db.models.template.destroy({where: {ident: templateUpdateBioinf.ident}, force: true});
     });
 
     test('/{template} - 200 Success', async () => {
@@ -254,6 +355,53 @@ describe('/templates', () => {
       await db.models.image.destroy({where: {ident: {[Op.in]: newImages}}, force: true});
     }, LONGER_TIMEOUT);
 
+    test('/{template} - 200 Success by manager', async () => {
+      const newImages = [];
+      const res = await request
+        .put(`${BASE_URI}/${templateUpdateManager.ident}`)
+        .attach('logo', 'test/testData/images/golden.jpg')
+        .attach('header', 'test/testData/images/golden.jpg')
+        .field('name', 'New Name - by manager')
+        .field('organization', 'New Orgs')
+        .field('description', 'New Description')
+        .field('sections', 'therapeutic-targets')
+        .field('sections', 'genes')
+        .auth(managerUsername, password)
+        .expect(HTTP_STATUS.OK);
+
+      checkTemplate(res.body);
+      expect(res.body).toEqual(expect.objectContaining({
+        name: 'New Name',
+        organization: 'New Orgs',
+        sections: ['therapeutic-targets', 'genes'],
+        description: 'New Description',
+        logoImage: expect.any(Object),
+        headerImage: expect.any(Object),
+      }));
+
+      expect(res.body.logoImage.ident).not.toBeNull();
+      newImages.push(res.body.logoImage.ident);
+      expect(res.body.headerImage.ident).not.toBeNull();
+      newImages.push(res.body.headerImage.ident);
+
+      // Delete template and images
+      await db.models.image.destroy({where: {ident: {[Op.in]: newImages}}, force: true});
+    }, LONGER_TIMEOUT);
+
+    test('/{template} - 403 - bioinformatician edit fails', async () => {
+      await request
+        .put(`${BASE_URI}/${templateUpdateBioinf.ident}`)
+        .attach('logo', 'test/testData/images/golden.jpg')
+        .attach('header', 'test/testData/images/golden.jpg')
+        .field('name', 'New Name')
+        .field('organization', 'New Orgs')
+        .field('description', 'New Description')
+        .field('sections', 'therapeutic-targets')
+        .field('sections', 'genes')
+        .auth(bioinformaticianUsername, password)
+        .expect(HTTP_STATUS.FORBIDDEN);
+    }, LONGER_TIMEOUT);
+
     test('/{template} - 400 Bad Request Failed Validation', async () => {
       await request
         .put(`${BASE_URI}/${templateUpdate.ident}`)
@@ -278,14 +426,24 @@ describe('/templates', () => {
 
   describe('DELETE', () => {
     let templateDelete;
+    let templateDeleteManager;
+    let templateDeleteBioinf;
 
     beforeEach(async () => {
       templateDelete = await db.models.template.create(DELETE_DATA);
+      templateDeleteManager = await db.models.template.create(DELETE_DATA_BY_MANAGER);
+      templateDeleteBioinf = await db.models.template.create(DELETE_DATA_BY_BIOINFORMATICIAN);
     });
 
     afterEach(async () => {
       await db.models.template.destroy({
         where: {ident: templateDelete.ident}, force: true,
+      });
+      await db.models.template.destroy({
+        where: {ident: templateDeleteManager.ident}, force: true,
+      });
+      await db.models.template.destroy({
+        where: {ident: templateDeleteBioinf.ident}, force: true,
       });
     });
 
@@ -299,6 +457,26 @@ describe('/templates', () => {
       // Verify that the record was deleted
       const result = await db.models.template.findOne({where: {id: templateDelete.id}});
       expect(result).toBeNull();
+    });
+
+    test('/{template} - 204 No content by manager', async () => {
+      await request
+        .delete(`${BASE_URI}/${templateDeleteManager.ident}`)
+        .auth(managerUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.NO_CONTENT);
+
+      // Verify that the record was deleted
+      const result = await db.models.template.findOne({where: {id: templateDeleteManager.id}});
+      expect(result).toBeNull();
+    });
+
+    test('/{template} - 403 bioinformatician delete fails', async () => {
+      await request
+        .delete(`${BASE_URI}/${templateDeleteBioinf.ident}`)
+        .auth(bioinformaticianUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.FORBIDDEN);
     });
 
     test('/{template} - 404 Not Found no template to delete', async () => {

--- a/test/routes/user/member.test.js
+++ b/test/routes/user/member.test.js
@@ -206,7 +206,7 @@ describe('/user/group/{group}/member', () => {
         email: 'updateUser@email.com',
       });
 
-      const res = await request
+      await request
         .post(`/api/user/group/${group.ident}/member`)
         .auth(bioinformaticianUsername, password)
         .type('json')

--- a/test/routes/user/member.test.js
+++ b/test/routes/user/member.test.js
@@ -9,7 +9,7 @@ const CONFIG = require('../../../app/config');
 const {listen} = require('../../../app');
 
 CONFIG.set('env', 'test');
-const {username, managerUsername, password} = CONFIG.get('testing');
+const {username, managerUsername, bioinformaticianUsername, password} = CONFIG.get('testing');
 
 const checkUser = (userObject) => {
   expect(userObject).toEqual(expect.objectContaining({
@@ -40,6 +40,7 @@ let request;
 
 // Variables to be used for group tests
 let group;
+let adminGroup;
 let user01;
 let user02;
 
@@ -68,6 +69,9 @@ beforeAll(async () => {
 
   // Create groups
   group = await db.models.userGroup.create({name: 'Test group', owner_id: user01.id});
+  adminGroup = await db.models.userGroup.findOne({
+    where: {name: 'admin'},
+  });
 
   // Make users group members
   await db.models.userGroupMember.create({user_id: user01.id, group_id: group.id});
@@ -120,6 +124,99 @@ describe('/user/group/{group}/member', () => {
       await db.models.user.destroy({where: {ident: updateUser.ident}, force: true});
     });
 
+    test('/ - 200 Success by manager', async () => {
+      // Create user
+      const updateUser = await db.models.user.create({
+        ident: uuidv4(),
+        username: uuidv4(),
+        firstName: 'updateUserFirstName',
+        lastName: 'updateUserLastName',
+        email: 'updateUser@email.com',
+      });
+
+      const res = await request
+        .post(`/api/user/group/${group.ident}/member`)
+        .auth(managerUsername, password)
+        .type('json')
+        .send({user: updateUser.ident})
+        .expect(HTTP_STATUS.CREATED);
+
+      checkUser(res.body);
+
+      // Check user belongs to group
+      const groupIdents = res.body.groups.map((g) => {
+        return g.ident;
+      });
+      expect(groupIdents.includes(group.ident)).toBe(true);
+
+      // Remove user
+      await db.models.user.destroy({where: {ident: updateUser.ident}, force: true});
+    });
+
+    test('/ - 403 forbidden to non-admin to give admin role', async () => {
+      // Create user
+      const updateUser = await db.models.user.create({
+        ident: uuidv4(),
+        username: uuidv4(),
+        firstName: 'updateUser1FirstName',
+        lastName: 'updateUser1LastName',
+        email: 'updateUser1@email.com',
+      });
+
+      await request
+        .post(`/api/user/group/${adminGroup.ident}/member`)
+        .auth(managerUsername, password)
+        .type('json')
+        .send({user: updateUser.ident})
+        .expect(HTTP_STATUS.FORBIDDEN);
+
+      // Remove user
+      await db.models.user.destroy({where: {ident: updateUser.ident}, force: true});
+    });
+
+    test('/ - 403 forbidden to non-admin to give role to admin user', async () => {
+      // Create user
+      const updateUser = await db.models.user.create({
+        ident: uuidv4(),
+        username: uuidv4(),
+        firstName: 'updateUser2FirstName',
+        lastName: 'updateUser2LastName',
+        email: 'updateUser2@email.com',
+      });
+
+      await db.models.userGroupMember.create({user_id: updateUser.id, group_id: adminGroup.id});
+      await request
+        .post(`/api/user/group/${group.ident}/member`)
+        .auth(managerUsername, password)
+        .type('json')
+        .send({user: updateUser.ident})
+        .expect(HTTP_STATUS.FORBIDDEN);
+
+      // Remove user
+      await db.models.user.destroy({where: {ident: updateUser.ident}, force: true});
+    });
+
+    test('/ - 403 forbidden to bioinformatician', async () => {
+      // Create user
+      const updateUser = await db.models.user.create({
+        ident: uuidv4(),
+        username: uuidv4(),
+        firstName: 'updateUserFirstName',
+        lastName: 'updateUserLastName',
+        email: 'updateUser@email.com',
+      });
+
+      const res = await request
+        .post(`/api/user/group/${group.ident}/member`)
+        .auth(bioinformaticianUsername, password)
+        .type('json')
+        .send({user: updateUser.ident})
+        .expect(HTTP_STATUS.FORBIDDEN);
+
+      // Remove user
+      await db.models.user.destroy({where: {ident: updateUser.ident}, force: true});
+    });
+
     test('/ - 400 Bad Request - User is required', async () => {
       await request
         .post(`/api/user/group/${group.ident}/member`)
@@ -138,28 +235,6 @@ describe('/user/group/{group}/member', () => {
         .expect(HTTP_STATUS.BAD_REQUEST);
     });
 
-    test('/ - 403 Forbidden - Non-admin user may not give admin role', async () => {
-      const nonAdminUser = await db.models.user.create({
-        ident: uuidv4(),
-        username: uuidv4(),
-        firstName: 'nonAdminFirstName',
-        lastName: 'nonAdminLastName',
-        email: 'updateUser@email.com',
-      });
-
-      console.log(managerUsername);
-      const req = await request
-        .post('/api/user/group/admin/member')
-        .auth(managerUsername, password)
-        .type('json')
-        .send({user: nonAdminUser.ident})
-        .expect(HTTP_STATUS.FORBIDDEN);
-      console.log('req');
-      console.dir(req.body);
-
-      await db.models.user.destroy({where: {ident: nonAdminUser.ident}, force: true});
-    });
-
     test('/ - 404 Not Found - User does not exist', async () => {
       await request
         .post(`/api/user/group/${group.ident}/member`)
@@ -173,6 +248,8 @@ describe('/user/group/{group}/member', () => {
   // Tests for DELETE endpoint
   describe('DELETE', () => {
     let deleteUser;
+    let deleteUser2;
+    let adminDeleteUser;
 
     beforeEach(async () => {
       deleteUser = await db.models.user.create({
@@ -183,13 +260,40 @@ describe('/user/group/{group}/member', () => {
         email: 'deleteUser@email.com',
       });
 
+      deleteUser2 = await db.models.user.create({
+        ident: uuidv4(),
+        username: uuidv4(),
+        firstName: 'deleteUser2FirstName',
+        lastName: 'deleteUser2LastName',
+        email: 'deleteUser2@email.com',
+      });
+
+      adminDeleteUser = await db.models.user.create({
+        ident: uuidv4(),
+        username: uuidv4(),
+        firstName: 'deleteUser1FirstName',
+        lastName: 'deleteUser1LastName',
+        email: 'deleteUser1@email.com',
+      });
+
       await db.models.userGroupMember.create({
         user_id: deleteUser.id, group_id: group.id,
+      });
+      await db.models.userGroupMember.create({
+        user_id: deleteUser2.id, group_id: group.id,
+      });
+      await db.models.userGroupMember.create({
+        user_id: adminDeleteUser.id, group_id: group.id,
+      });
+      await db.models.userGroupMember.create({
+        user_id: adminDeleteUser.id, group_id: adminGroup.id,
       });
     });
 
     afterEach(async () => {
-      return db.models.user.destroy({where: {ident: deleteUser.ident}, force: true});
+      await db.models.user.destroy({where: {ident: deleteUser.ident}, force: true});
+      await db.models.user.destroy({where: {ident: deleteUser2.ident}, force: true});
+      await db.models.user.destroy({where: {ident: adminDeleteUser.ident}, force: true});
     });
 
     test('/ - 204 Success', async () => {
@@ -207,16 +311,49 @@ describe('/user/group/{group}/member', () => {
       expect(delGroupMember.deletedAt).not.toBeNull();
     });
 
-    test('/ - 400 Bad Request', async () => {
+    test('/ - 204 Success by manager', async () => {
       await request
         .delete(`/api/user/group/${group.ident}/member`)
-        .auth(username, password)
+        .auth(managerUsername, password)
         .type('json')
-        .send({user: 'INVALID_UUID'})
-        .expect(HTTP_STATUS.BAD_REQUEST);
+        .send({user: deleteUser2.ident})
+        .expect(HTTP_STATUS.NO_CONTENT);
+
+      // Verify group-member association is deleted
+      const delGroupMember = await db.models.userGroupMember.findOne({
+        where: {user_id: deleteUser2.id, group_id: group.id}, paranoid: false,
+      });
+      expect(delGroupMember.deletedAt).not.toBeNull();
     });
 
-    test('/ - 403 Forbidden - non-admin may not edit admin user', async () => {
+    test('/ - 403 forbidden to non-admin to remove admin role', async () => {
+      await request
+        .delete(`/api/user/group/${adminGroup.ident}/member`)
+        .auth(managerUsername, password)
+        .type('json')
+        .send({user: adminDeleteUser.ident})
+        .expect(HTTP_STATUS.FORBIDDEN);
+    });
+
+    test('/ - 403 forbidden to non-admin to remove any role from admin user', async () => {
+      await request
+        .delete(`/api/user/group/${group.ident}/member`)
+        .auth(managerUsername, password)
+        .type('json')
+        .send({user: adminDeleteUser.ident})
+        .expect(HTTP_STATUS.FORBIDDEN);
+    });
+
+    test('/ - 403 forbidden to bioinformatician', async () => {
+      await request
+        .delete(`/api/user/group/${group.ident}/member`)
+        .auth(bioinformaticianUsername, password)
+        .type('json')
+        .send({user: deleteUser.ident})
+        .expect(HTTP_STATUS.FORBIDDEN);
+    });
+
+    test('/ - 400 Bad Request', async () => {
       await request
         .delete(`/api/user/group/${group.ident}/member`)
         .auth(username, password)

--- a/test/routes/user/user.test.js
+++ b/test/routes/user/user.test.js
@@ -9,7 +9,7 @@ const CONFIG = require('../../../app/config');
 const {listen} = require('../../../app');
 
 CONFIG.set('env', 'test');
-const {username, password} = CONFIG.get('testing');
+const {username, managerUsername, bioinformaticianUsername, password} = CONFIG.get('testing');
 
 const userProperties = [
   'ident', 'createdAt', 'updatedAt', 'username',
@@ -46,11 +46,15 @@ beforeAll(async () => {
 // Tests for user related endpoints
 describe('/user', () => {
   let testUser;
+  let adminGroup;
 
   beforeAll(async () => {
     // get test user
     testUser = await db.models.user.findOne({
       where: {username},
+    });
+    adminGroup = await db.models.userGroup.findOne({
+      where: {name: 'admin'},
     });
   });
 
@@ -162,6 +166,39 @@ describe('/user', () => {
       await db.models.user.destroy({where: {ident: res.body.ident}, force: true});
     });
 
+    test('/ - 200 Success by manager', async () => {
+      const res = await request
+        .post('/api/user')
+        .auth(managerUsername, password)
+        .type('json')
+        .send({
+          username: `Testuser-${uuidv4()}`,
+          type: 'bcgsc',
+          email: 'testuser1@test.com',
+          firstName: 'FirstName1Test',
+          lastName: 'LastName1Test',
+        })
+        .expect(HTTP_STATUS.CREATED);
+
+      // Remove test user from db
+      await db.models.user.destroy({where: {ident: res.body.ident}, force: true});
+    });
+
+    test('/ - 403 forbidden for bioinformatician', async () => {
+      await request
+        .post('/api/user')
+        .auth(bioinformaticianUsername, password)
+        .type('json')
+        .send({
+          username: `Testuser-${uuidv4()}`,
+          type: 'bcgsc',
+          email: 'testuser2@test.com',
+          firstName: 'FirstName2Test',
+          lastName: 'LastName2Test',
+        })
+        .expect(HTTP_STATUS.FORBIDDEN);
+    });
+
     test('/ - 409 Conflict - Username taken', async () => {
       await request
         .post('/api/user')
@@ -254,6 +291,7 @@ describe('/user', () => {
 
   describe('PUT', () => {
     let putTestUser;
+    let adminPutTestUser;
 
     beforeEach(async () => {
       putTestUser = await db.models.user.create({
@@ -263,10 +301,22 @@ describe('/user', () => {
         firstName: 'putTestFirstName',
         lastName: 'putTestLastName',
       });
+      adminPutTestUser = await db.models.user.create({
+        username: `putTestUser-${uuidv4()}`,
+        type: 'bcgsc',
+        email: 'putTest@email.com',
+        firstName: 'putTestFirstName',
+        lastName: 'putTestLastName',
+      });
+
+      await db.models.userGroupMember.create({
+        user_id: adminPutTestUser.id, group_id: adminGroup.id,
+      });
     });
 
     afterEach(async () => {
-      return db.models.user.destroy({where: {ident: putTestUser.ident}, force: true});
+      await db.models.user.destroy({where: {ident: putTestUser.ident}, force: true});
+      await db.models.user.destroy({where: {ident: adminPutTestUser.ident}, force: true});
     });
 
     test('/{user} - 200 Success', async () => {
@@ -281,6 +331,38 @@ describe('/user', () => {
       expect(res.body.firstName).toBe('NewFirstName');
     });
 
+    test('/{user} - 200 Success by manager', async () => {
+      const res = await request
+        .put(`/api/user/${putTestUser.ident}`)
+        .send({firstName: 'NewFirstName-manager'})
+        .auth(managerUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      checkUser(res.body);
+      expect(res.body.firstName).toBe('NewFirstName-manager');
+    });
+
+    test('/{user} - 403 - forbidden to manager when user is admin', async () => {
+      await request
+        .put(`/api/user/${adminPutTestUser.ident}`)
+        .send({firstName: 'NewFirstName'})
+        .auth(managerUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.FORBIDDEN);
+    });
+
+    test('/{user} - 403 - forbidden to bioinformatician', async () => {
+      await request
+        .put(`/api/user/${putTestUser.ident}`)
+        .send({firstName: 'NewFirstName'})
+        .auth(bioinformaticianUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.FORBIDDEN);
+    });
+
+    // add test that non-admins can't edit admin users
+
     test('/{user} - 400 Bad Request - Invalid email', async () => {
       await request
         .put(`/api/user/${putTestUser.ident}`)
@@ -293,6 +375,9 @@ describe('/user', () => {
 
   describe('DELETE', () => {
     let deleteTestUser;
+    let deleteTestUserManager;
+    let deleteTestUserForbidden;
+    let deleteTestUserWhoIsAdmin;
 
     beforeEach(async () => {
       deleteTestUser = await db.models.user.create({
@@ -301,10 +386,34 @@ describe('/user', () => {
         lastName: 'deleteLastName01',
         email: 'delete@email.com',
       });
+      deleteTestUserManager = await db.models.user.create({
+        username: uuidv4(),
+        firstName: 'delete1FirstName01',
+        lastName: 'delete1LastName01',
+        email: 'delete1@email.com',
+      });
+      deleteTestUserForbidden = await db.models.user.create({
+        username: uuidv4(),
+        firstName: 'delete2FirstName01',
+        lastName: 'delete2LastName01',
+        email: 'delete2@email.com',
+      });
+      deleteTestUserWhoIsAdmin = await db.models.user.create({
+        username: uuidv4(),
+        firstName: 'delete3FirstName01',
+        lastName: 'delete3LastName01',
+        email: 'delete3@email.com',
+      });
+      await db.models.userGroupMember.create({
+        user_id: deleteTestUserWhoIsAdmin.id, group_id: adminGroup.id,
+      });
     });
 
     afterEach(async () => {
-      return db.models.user.destroy({where: {ident: deleteTestUser.ident}, force: true});
+      await db.models.user.destroy({where: {ident: deleteTestUser.ident}, force: true});
+      await db.models.user.destroy({where: {ident: deleteTestUserManager.ident}, force: true});
+      await db.models.user.destroy({where: {ident: deleteTestUserForbidden.ident}, force: true});
+      await db.models.user.destroy({where: {ident: deleteTestUserWhoIsAdmin.ident}, force: true});
     });
 
     test('/{user} - 204 Success', async () => {
@@ -319,6 +428,36 @@ describe('/user', () => {
         where: {ident: deleteTestUser.ident}, paranoid: false,
       });
       expect(deletedUser.deletedAt).not.toBeNull();
+    });
+
+    test('/{user} - 204 Success by manager', async () => {
+      await request
+        .delete(`/api/user/${deleteTestUserManager.ident}`)
+        .auth(managerUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.NO_CONTENT);
+
+      // Verify user is soft-deleted
+      const deletedUser = await db.models.user.findOne({
+        where: {ident: deleteTestUserManager.ident}, paranoid: false,
+      });
+      expect(deletedUser.deletedAt).not.toBeNull();
+    });
+
+    test('/{user} - 403 forbidden to manager when user is admin', async () => {
+      await request
+        .delete(`/api/user/${deleteTestUserWhoIsAdmin.ident}`)
+        .auth(managerUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.FORBIDDEN);
+    });
+
+    test('/{user} - 403 forbidden to bioinformatician', async () => {
+      await request
+        .delete(`/api/user/${deleteTestUserForbidden.ident}`)
+        .auth(bioinformaticianUsername, password)
+        .type('json')
+        .expect(HTTP_STATUS.FORBIDDEN);
     });
 
     test('/{user} - 404 Not Found', async () => {

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -14,6 +14,7 @@ beforeAll(async () => {
   // managerUser = await db.models.user.findOne({
   //  where: {username: managerUsername},
   // });
+  const adminUser = await db.models.user.findOne({where:{username: 'admin'}});
   const [managerUser] = await db.models.user.findOrCreate({
     where: {
       username: managerUsername,
@@ -26,6 +27,7 @@ beforeAll(async () => {
   const [managerGroup] = await db.models.userGroup.findOrCreate({
     where: {
       name: 'manager',
+      owner_id: adminUser.id,
     },
   });
 
@@ -45,6 +47,7 @@ beforeAll(async () => {
   const [bioinformaticianGroup] = await db.models.userGroup.findOrCreate({
     where: {
       name: 'Bioinformatician',
+      owner_id: adminUser.id,
     },
   });
 

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -1,0 +1,60 @@
+const {v4: uuidv4} = require('uuid');
+
+const db = require('../app/models');
+// get test user info
+const CONFIG = require('../app/config');
+
+CONFIG.set('env', 'test');
+const {managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
+
+let managerUser;
+let managerGroup;
+let bioinformaticianUser;
+let bioinformaticianGroup;
+
+// Start API
+beforeAll(async () => {
+  managerUser = await db.models.user.findOne({
+    where: {username: managerUsername},
+  });
+  if (!managerUser) {
+    managerUser = await db.models.user.create({
+      ident: uuidv4(),
+      username: 'ipr-bamboo-manager',
+      firstName: 'ipr-bamboo-manager',
+      lastName: 'ipr-bamboo-manager',
+      email: 'dat@bcgsc.ca',
+    });
+  }
+  managerGroup = await db.models.userGroup.findOne({
+    where: {name: 'manager'},
+  });
+  await db.models.userGroupMember.findOrCreate({
+    where: {user_id: managerUser.id, group_id: managerGroup.id},
+  });
+
+  bioinformaticianUser = await db.models.user.findOne({
+    where: {username: bioinformaticianUsername},
+  });
+  if (!bioinformaticianUser) {
+    bioinformaticianUser = await db.models.user.create({
+      ident: uuidv4(),
+      username: 'ipr-bamboo-bioinformatician',
+      firstName: 'ipr-bamboo-bioinformatician',
+      lastName: 'ipr-bamboo-bioinformatician',
+      email: 'dat@bcgsc.ca',
+    });
+  }
+  bioinformaticianGroup = await db.models.userGroup.findOne({
+    where: {name: 'Bioinformatician'},
+  });
+  if (!bioinformaticianGroup) {
+    bioinformaticianGroup = await db.models.userGroup.create({
+      ident: uuidv4(),
+      name: 'Bioinformatician',
+    });
+  }
+  await db.models.userGroupMember.findOrCreate({
+    where: {user_id: bioinformaticianUser.id, group_id: bioinformaticianGroup.id},
+  });
+});

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -5,10 +5,8 @@ const CONFIG = require('../app/config');
 CONFIG.set('env', 'test');
 const {username, managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
-
 beforeAll(async () => {
-
-  const adminUser = await db.models.user.findOne({where:{username: username}});
+  const adminUser = await db.models.user.findOne({where: {username}});
   const [managerUser] = await db.models.user.findOrCreate({
     where: {
       username: managerUsername,

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -56,6 +56,7 @@ beforeAll(async () => {
     bioinformaticianGroup = await db.models.userGroup.create({
       ident: uuidv4(),
       name: 'Bioinformatician',
+      owner_id: managerUser.id,
     });
   }
   await db.models.userGroupMember.findOrCreate({

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -8,7 +8,7 @@ CONFIG.set('env', 'test');
 const {managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
 // Start API
-module.exports(async () => {
+module.exports = async () => {
   let managerUser;
   let managerGroup;
   let bioinformaticianUser;

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -7,8 +7,7 @@ const CONFIG = require('../app/config');
 CONFIG.set('env', 'test');
 const {managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
-// Start API
-module.exports = async () => {
+beforeAll(async () => {
   let managerUser;
   let managerGroup;
   let bioinformaticianUser;
@@ -62,4 +61,4 @@ module.exports = async () => {
   await db.models.userGroupMember.findOrCreate({
     where: {user_id: bioinformaticianUser.id, group_id: bioinformaticianGroup.id},
   });
-};
+});

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -1,5 +1,3 @@
-const {v4: uuidv4} = require('uuid');
-
 const db = require('../app/models');
 // get test user info
 const CONFIG = require('../app/config');
@@ -11,65 +9,45 @@ const {managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 // remove fixed idents here
 
 beforeAll(async () => {
-  let managerUser;
-  let managerGroup;
-  let bioinformaticianUser;
-  let bioinformaticianGroup;
-  managerUser = await db.models.user.findOne({
-    where: {username: managerUsername},
-  });
-  if (!managerUser) {
-    managerUser = await db.models.user.findOrCreate({
-      where: {
-      ident: '2a46cd1e-913f-4e7c-a055-0050d0586ed2',
+  // let managerUser;
+
+  // managerUser = await db.models.user.findOne({
+  //  where: {username: managerUsername},
+  // });
+  const [managerUser] = await db.models.user.findOrCreate({
+    where: {
       username: managerUsername,
       firstName: managerUsername,
       lastName: managerUsername,
-      email: 'dat@bcgsc.ca',
-      }
-    });
-  }
-  managerGroup = await db.models.userGroup.findOne({
-    where: {name: 'manager'},
+      email: 'ipr@bcgsc.ca',
+    },
   });
-  if (!managerGroup) {
-    managerGroup = await db.models.userGroup.findOrCreate({
-      where: {
-      ident: 'c748c8d9-af5b-4a53-b94f-410eef89f8d0',
+
+  const [managerGroup] = await db.models.userGroup.findOrCreate({
+    where: {
       name: 'manager',
-      }
-    });
-  }
-  const managerAddedToGroup = await db.models.userGroupMember.findOrCreate({
+    },
+  });
+
+  await db.models.userGroupMember.findOrCreate({
     where: {user_id: managerUser.id, group_id: managerGroup.id},
   });
 
-  bioinformaticianUser = await db.models.user.findOne({
-    where: {username: bioinformaticianUsername},
-  });
-  if (!bioinformaticianUser) {
-    bioinformaticianUser = await db.models.user.findOrCreate({
-      where: {
-      ident: '5080af7a-8b6b-4249-b026-d2e781bd8efa',
+  const [bioinformaticianUser] = await db.models.user.findOrCreate({
+    where: {
       username: bioinformaticianUsername,
       firstName: bioinformaticianUsername,
       lastName: bioinformaticianUsername,
-      email: 'dat@bcgsc.ca',
-      }
-    });
-  }
-  bioinformaticianGroup = await db.models.userGroup.findOne({
-    where: {name: 'Bioinformatician'},
+      email: 'ipr@bcgsc.ca',
+    },
   });
-  if (!bioinformaticianGroup) {
-    bioinformaticianGroup = await db.models.userGroup.findOrCreate({
-      where: {
-      ident: '3dfcf75e-fed8-11e6-bc64-92361f002671',
+
+  const [bioinformaticianGroup] = await db.models.userGroup.findOrCreate({
+    where: {
       name: 'Bioinformatician',
-      owner_id: managerUser.id,
-      }
-    });
-  }
+    },
+  });
+
   await db.models.userGroupMember.findOrCreate({
     where: {user_id: bioinformaticianUser.id, group_id: bioinformaticianGroup.id},
   });

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -1,19 +1,13 @@
 const db = require('../app/models');
-// get test user info
+
 const CONFIG = require('../app/config');
 
 CONFIG.set('env', 'test');
 const {username, managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
-// TODO: move uuid creation to defaults for ident fields in the db;
-// remove fixed idents here
 
 beforeAll(async () => {
-  // let managerUser;
 
-  // managerUser = await db.models.user.findOne({
-  //  where: {username: managerUsername},
-  // });
   const adminUser = await db.models.user.findOne({where:{username: username}});
   const [managerUser] = await db.models.user.findOrCreate({
     where: {

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -3,7 +3,7 @@ const db = require('../app/models');
 const CONFIG = require('../app/config');
 
 CONFIG.set('env', 'test');
-const {managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
+const {user, managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
 // TODO: move uuid creation to defaults for ident fields in the db;
 // remove fixed idents here
@@ -14,7 +14,7 @@ beforeAll(async () => {
   // managerUser = await db.models.user.findOne({
   //  where: {username: managerUsername},
   // });
-  const adminUser = await db.models.user.findOne({where:{username: 'admin'}});
+  const adminUser = await db.models.user.findOne({where:{username: user}});
   const [managerUser] = await db.models.user.findOrCreate({
     where: {
       username: managerUsername,

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -3,7 +3,7 @@ const db = require('../app/models');
 const CONFIG = require('../app/config');
 
 CONFIG.set('env', 'test');
-const {user, managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
+const {username, managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
 // TODO: move uuid creation to defaults for ident fields in the db;
 // remove fixed idents here
@@ -14,7 +14,7 @@ beforeAll(async () => {
   // managerUser = await db.models.user.findOne({
   //  where: {username: managerUsername},
   // });
-  const adminUser = await db.models.user.findOne({where:{username: user}});
+  const adminUser = await db.models.user.findOne({where:{username: username}});
   const [managerUser] = await db.models.user.findOrCreate({
     where: {
       username: managerUsername,

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -7,13 +7,12 @@ const CONFIG = require('../app/config');
 CONFIG.set('env', 'test');
 const {managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
-let managerUser;
-let managerGroup;
-let bioinformaticianUser;
-let bioinformaticianGroup;
-
 // Start API
-beforeAll(async () => {
+module.exports(async () => {
+  let managerUser;
+  let managerGroup;
+  let bioinformaticianUser;
+  let bioinformaticianGroup;
   managerUser = await db.models.user.findOne({
     where: {username: managerUsername},
   });
@@ -29,6 +28,12 @@ beforeAll(async () => {
   managerGroup = await db.models.userGroup.findOne({
     where: {name: 'manager'},
   });
+  if (!managerGroup) {
+    managerGroup = await db.models.userGroup.create({
+      ident: uuidv4(),
+      name: 'manager',
+    });
+  }
   await db.models.userGroupMember.findOrCreate({
     where: {user_id: managerUser.id, group_id: managerGroup.id},
   });

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -7,6 +7,9 @@ const CONFIG = require('../app/config');
 CONFIG.set('env', 'test');
 const {managerUsername, bioinformaticianUsername} = CONFIG.get('testing');
 
+// TODO: move uuid creation to defaults for ident fields in the db;
+// remove fixed idents here
+
 beforeAll(async () => {
   let managerUser;
   let managerGroup;
@@ -16,24 +19,28 @@ beforeAll(async () => {
     where: {username: managerUsername},
   });
   if (!managerUser) {
-    managerUser = await db.models.user.create({
-      ident: uuidv4(),
-      username: 'ipr-bamboo-manager',
-      firstName: 'ipr-bamboo-manager',
-      lastName: 'ipr-bamboo-manager',
+    managerUser = await db.models.user.findOrCreate({
+      where: {
+      ident: '2a46cd1e-913f-4e7c-a055-0050d0586ed2',
+      username: managerUsername,
+      firstName: managerUsername,
+      lastName: managerUsername,
       email: 'dat@bcgsc.ca',
+      }
     });
   }
   managerGroup = await db.models.userGroup.findOne({
     where: {name: 'manager'},
   });
   if (!managerGroup) {
-    managerGroup = await db.models.userGroup.create({
-      ident: uuidv4(),
+    managerGroup = await db.models.userGroup.findOrCreate({
+      where: {
+      ident: 'c748c8d9-af5b-4a53-b94f-410eef89f8d0',
       name: 'manager',
+      }
     });
   }
-  await db.models.userGroupMember.findOrCreate({
+  const managerAddedToGroup = await db.models.userGroupMember.findOrCreate({
     where: {user_id: managerUser.id, group_id: managerGroup.id},
   });
 
@@ -41,22 +48,26 @@ beforeAll(async () => {
     where: {username: bioinformaticianUsername},
   });
   if (!bioinformaticianUser) {
-    bioinformaticianUser = await db.models.user.create({
-      ident: uuidv4(),
-      username: 'ipr-bamboo-bioinformatician',
-      firstName: 'ipr-bamboo-bioinformatician',
-      lastName: 'ipr-bamboo-bioinformatician',
+    bioinformaticianUser = await db.models.user.findOrCreate({
+      where: {
+      ident: '5080af7a-8b6b-4249-b026-d2e781bd8efa',
+      username: bioinformaticianUsername,
+      firstName: bioinformaticianUsername,
+      lastName: bioinformaticianUsername,
       email: 'dat@bcgsc.ca',
+      }
     });
   }
   bioinformaticianGroup = await db.models.userGroup.findOne({
     where: {name: 'Bioinformatician'},
   });
   if (!bioinformaticianGroup) {
-    bioinformaticianGroup = await db.models.userGroup.create({
-      ident: uuidv4(),
+    bioinformaticianGroup = await db.models.userGroup.findOrCreate({
+      where: {
+      ident: '3dfcf75e-fed8-11e6-bc64-92361f002671',
       name: 'Bioinformatician',
       owner_id: managerUser.id,
+      }
     });
   }
   await db.models.userGroupMember.findOrCreate({

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -62,4 +62,4 @@ module.exports = async () => {
   await db.models.userGroupMember.findOrCreate({
     where: {user_id: bioinformaticianUser.id, group_id: bioinformaticianGroup.id},
   });
-});
+};


### PR DESCRIPTION
Allows managers to add and edit users, add and remove user projects where the manager also has the project, add and remove user groups if the user is not admin and the group is not admin.
Allows managers to add and edit templates and template appendix text.