### PR TITLE
bugfix/DEVSU-2460-make-template-signaturetype--return-empty-array-when-get

### DIFF
--- a/app/routes/template/templateSignatureTypes.js
+++ b/app/routes/template/templateSignatureTypes.js
@@ -41,7 +41,7 @@ router.use('/', async (req, res, next) => {
   }
 
   // Throw an error for everything but a POST if the signature doesn't exist
-  if ((!req.templateSignatureTypes || req.templateSignatureTypes.length === 0) && req.method !== 'POST') {
+  if ((!req.templateSignatureTypes || req.templateSignatureTypes.length === 0) && req.method === 'DELETE') {
     logger.error(`Template signature type does not exist for ${req.template.name}`);
     return res.status(HTTP_STATUS.NOT_FOUND).json({
       error: {message: `Template signature type does not exist for ${req.template.name}`},

--- a/test/routes/template/templateSignatureTypes.test.js
+++ b/test/routes/template/templateSignatureTypes.test.js
@@ -82,15 +82,17 @@ describe('/templates/{template}/signature-types', () => {
       expect(res.body[0]).toEqual(expect.objectContaining(CREATE_DATA));
     });
 
-    test('/ - 404 Not Found', async () => {
+    test('/ - 200 Success - empty array', async () => {
       // Soft delete signature types
       await getTestSignatureType.destroy();
 
-      await request
+      const res = await request
         .get(`/api/templates/${template.ident}/signature-types`)
         .auth(username, password)
         .type('json')
-        .expect(HTTP_STATUS.NOT_FOUND);
+        .expect(HTTP_STATUS.OK);
+
+      expect(res.body).toEqual([]);
     });
   });
 


### PR DESCRIPTION
[DEVSU-2460](https://www.bcgsc.ca/jira/browse/DEVSU-2460)
- template signature type get return empty array when signature not exist