### PR TITLE
bugfix/DEVSU-2524 Re-order evidence levels for client tooltip dialog

### DIFF
--- a/app/api/graphkb.js
+++ b/app/api/graphkb.js
@@ -90,6 +90,7 @@ const graphkbEvidenceLevels = async (graphkbToken) => {
         filters: {name: 'ipr'},
       },
     },
+    orderBy: 'displayName',
     limit: 100,
     skip: 0,
     target: 'EvidenceLevel',


### PR DESCRIPTION
- DEVSU-2524
- Order evidence levels from GraphKB by display name (IPR-A -> IPR-E)