### PR TITLE
[DEVSU-2468] add POST route to gkb user creation

### DIFF
--- a/app/routes/graphkb/index.js
+++ b/app/routes/graphkb/index.js
@@ -73,9 +73,9 @@ router.post('/new-user', async (req, res) => {
     }
     return res.status(StatusCodes.CREATED).json();
   } catch (error) {
-    logger.error(error);
+    logger.error(`Error trying to create user on GraphKB, ${error}`);
     return res.status(StatusCodes.SERVICE_UNAVAILABLE).json({
-      message: 'GraphKB user creation error',
+      error: {message: `GraphKB user creation error: ${error}`},
     });
   }
 });


### PR DESCRIPTION
Separate graphkb user creation from ipr user creation, so everything is more in sync in the front-end

See DESVU-2468 for current blocker, which is not enough permissions on IPR API agent user