### PR TITLE
DEVSU-2570 add rapid report summary filtering by tag

### DIFF
--- a/test/routes/report/variants.test.js
+++ b/test/routes/report/variants.test.js
@@ -180,7 +180,6 @@ describe('/reports/{REPORTID}/kb-matches', () => {
       expect(Array.isArray(res.body)).toBe(true);
       checkVariants(res.body[0]);
 
-      console.dir(res.body);
       checkVariantsFilter(
         res.body,
         'table 3',

--- a/test/routes/report/variants.test.js
+++ b/test/routes/report/variants.test.js
@@ -114,6 +114,23 @@ describe('/reports/{REPORTID}/kb-matches', () => {
       );
     });
 
+    test('Getting Therapeutic Association - gets by tag', async () => {
+      const res = await request
+        .get(`/api/reports/${rapidReportIdent.ident}/variants`)
+        .query({rapidTable: 'therapeuticAssociation'})
+        .auth(username, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      checkVariants(res.body[0]);
+
+      const taggedVariants = res.body.filter((variant) => {
+        return variant?.gene?.name === 'table1CV-3-tag-test';
+      });
+      expect(taggedVariants.length).toEqual(1);
+    });
+
     test('Getting Cancer Relevance - OK', async () => {
       const res = await request
         .get(`/api/reports/${rapidReportIdent.ident}/variants`)
@@ -135,6 +152,23 @@ describe('/reports/{REPORTID}/kb-matches', () => {
       );
     });
 
+    test('Getting Cancer Relevance - gets by tag', async () => {
+      const res = await request
+        .get(`/api/reports/${rapidReportIdent.ident}/variants`)
+        .query({rapidTable: 'cancerRelevance'})
+        .auth(username, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      checkVariants(res.body[0]);
+
+      const taggedVariants = res.body.filter((variant) => {
+        return variant?.gene?.name === 'table1CV-1-tag-test';
+      });
+      expect(taggedVariants.length).toEqual(1);
+    });
+
     test('Getting Unknown Significance - OK', async () => {
       const res = await request
         .get(`/api/reports/${rapidReportIdent.ident}/variants`)
@@ -146,6 +180,7 @@ describe('/reports/{REPORTID}/kb-matches', () => {
       expect(Array.isArray(res.body)).toBe(true);
       checkVariants(res.body[0]);
 
+      console.dir(res.body);
       checkVariantsFilter(
         res.body,
         'table 3',
@@ -154,6 +189,23 @@ describe('/reports/{REPORTID}/kb-matches', () => {
         res.body,
         'table 3',
       );
+    });
+
+    test('Getting Unknown Significance - gets by tag', async () => {
+      const res = await request
+        .get(`/api/reports/${rapidReportIdent.ident}/variants`)
+        .query({rapidTable: 'unknownSignificance'})
+        .auth(username, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      expect(Array.isArray(res.body)).toBe(true);
+      checkVariants(res.body[0]);
+
+      const taggedVariants = res.body.filter((variant) => {
+        return variant?.gene.name === 'table1CV-2-tag-test';
+      });
+      expect(taggedVariants.length).toEqual(1);
     });
   });
 

--- a/test/testData/mockRapidReportData.json
+++ b/test/testData/mockRapidReportData.json
@@ -27,7 +27,12 @@
             "kbVariantId": "#21",
             "kbStatementId": "#21",
             "kbData": {
-                "rapidReportSummaryTag": "cancerRelevance"
+                "rapidReportSummaryTags": [
+                    {
+                        "kbVariantId": "#21",
+                        "tag": "cancerRelevance"
+                    }
+                ]
             }
         },
         {
@@ -42,7 +47,12 @@
             "kbVariantId": "#22",
             "kbStatementId": "#22",
             "kbData": {
-                "rapidReportSummaryTag": "unknown"
+                "rapidReportSummaryTags": [
+                    {
+                        "kbVariantId": "#22",
+                        "tag": "unknown"
+                    }
+                ]
             }
         },
         {
@@ -57,7 +67,12 @@
             "kbVariantId": "#23",
             "kbStatementId": "#23",
             "kbData": {
-                "rapidReportSummaryTag": "therapeutic"
+                "rapidReportSummaryTags": [
+                    {
+                        "kbVariantId": "#23",
+                        "tag": "therapeutic"
+                    }
+                ]
             }
         },
         {

--- a/test/testData/mockRapidReportData.json
+++ b/test/testData/mockRapidReportData.json
@@ -18,6 +18,51 @@
         {
             "category": "therapeutic",
             "variantType": "cnv",
+            "variant": "TA-rapidReportSummaryTagTest-1",
+            "iprEvidenceLevel": "IPR-A",
+            "kbVariant": "this should be in table 2 because of rapid report summary tag",
+            "matchedCancer": true,
+            "relevance": "sensitivity",
+            "evidenceLevel": "table 2",
+            "kbVariantId": "#21",
+            "kbStatementId": "#21",
+            "kbData": {
+                "rapidReportSummaryTag": "cancerRelevance"
+            }
+        },
+        {
+            "category": "therapeutic",
+            "variantType": "cnv",
+            "variant": "TA-rapidReportSummaryTagTest-2",
+            "iprEvidenceLevel": "IPR-A",
+            "kbVariant": "this should be in table 3 because of rapid report summary tag",
+            "matchedCancer": true,
+            "relevance": "sensitivity",
+            "evidenceLevel": "table 3",
+            "kbVariantId": "#22",
+            "kbStatementId": "#22",
+            "kbData": {
+                "rapidReportSummaryTag": "unknown"
+            }
+        },
+        {
+            "category": "therapeutic",
+            "variantType": "cnv",
+            "variant": "TA-rapidReportSummaryTagTest-3",
+            "iprEvidenceLevel": "IPR-B",
+            "kbVariant": "this should be in table 1 because of rapid report summary tag",
+            "matchedCancer": true,
+            "relevance": "resistance",
+            "evidenceLevel": "table 1",
+            "kbVariantId": "#23",
+            "kbStatementId": "#23",
+            "kbData": {
+                "rapidReportSummaryTag": "therapeutic"
+            }
+        },
+        {
+            "category": "therapeutic",
+            "variantType": "cnv",
             "variant": "TA",
             "iprEvidenceLevel": "IPR-A",
             "kbVariant": "this should be in table 1",
@@ -252,6 +297,15 @@
         },
         {
             "name": "table2CV"
+        },
+        {
+            "name": "table1CV-1-tag-test"
+        },
+        {
+            "name": "table1CV-2-tag-test"
+        },
+        {
+            "name": "table1CV-3-tag-test"
         }
     ],
     "smallMutations": [
@@ -290,6 +344,21 @@
         {
             "gene": "table1CV",
             "key": "TA",
+            "displayName": "table 1"
+        },
+        {
+            "gene": "table1CV-1-tag-test",
+            "key": "TA-rapidReportSummaryTagTest-1",
+            "displayName": "table 2"
+        },
+        {
+            "gene": "table1CV-2-tag-test",
+            "key": "TA-rapidReportSummaryTagTest-2",
+            "displayName": "table 3"
+        },
+        {
+            "gene": "table1CV-3-tag-test",
+            "key": "TA-rapidReportSummaryTagTest-3",
             "displayName": "table 1"
         },
         {


### PR DESCRIPTION
For the rapid report summary table, adds filtering by tag in kbData statement field. This filtering is optional but if present the tag overrides other checks. This update will enable a client update to allow users to modify the contents of the rapid report summary tables.