### PR TITLE
if stmt filter, get only vars with stmts

### DIFF
--- a/app/routes/report/kbMatch/kbMatches.js
+++ b/app/routes/report/kbMatch/kbMatches.js
@@ -33,6 +33,12 @@ router.route('/')
   .get(async (req, res) => {
     const {query: {matchedCancer, approvedTherapy, category, iprEvidenceLevel}} = req;
 
+    const statementParams = [matchedCancer, approvedTherapy, category, iprEvidenceLevel];
+    let statementRequired = false;
+    if (statementParams.some(param => param !== null)) {
+      statementRequired = true;
+    }
+
     try {
       const results = await db.models.kbMatches.scope('public').findAll({
         where: {
@@ -53,13 +59,15 @@ router.route('/')
               ...((typeof approvedTherapy === 'boolean') ? {approvedTherapy} : {}),
             },
             through: {attributes: []},
-            required: false,
+            required: statementRequired,
           },
           ...Object.values(KB_PIVOT_MAPPING).map((modelName) => {
             return {model: db.models[modelName].scope('public'), as: modelName};
           }),
         ],
       });
+
+
 
       return res.json(results);
     } catch (error) {

--- a/app/routes/report/kbMatch/kbMatches.js
+++ b/app/routes/report/kbMatch/kbMatches.js
@@ -35,7 +35,7 @@ router.route('/')
 
     const statementParams = [matchedCancer, approvedTherapy, category, iprEvidenceLevel];
     let statementRequired = false;
-    if (statementParams.some(param => param !== null)) {
+    if (statementParams.some((param) => {return param !== null;})) {
       statementRequired = true;
     }
 
@@ -66,8 +66,6 @@ router.route('/')
           }),
         ],
       });
-
-
 
       return res.json(results);
     } catch (error) {


### PR DESCRIPTION
If there is a filter on the type of statement the kbmatch should be part of (eg category, evidence level), exclude kbmatches from the result if there are no associated matching statements.