### PR TITLE
prevent dupes and add test

### DIFF
--- a/app/libs/createReport.js
+++ b/app/libs/createReport.js
@@ -9,6 +9,7 @@ const {sanitizeHtml} = require('./helperFunctions');
 
 const EXCLUDE_SECTIONS = new Set([
   ...GENE_LINKED_VARIANT_MODELS,
+  ...Object.values(KB_PIVOT_MAPPING),
   'createdBy',
   'template',
   'genes',
@@ -337,7 +338,7 @@ const createReportSections = async (report, content, transaction) => {
   Object.keys(db.models.report.associations).filter((model) => {
     return !EXCLUDE_SECTIONS.has(model);
   }).forEach((model) => {
-    logger.debug(`creating report (${model}) section (${report.ident})`);
+    logger.info(`creating report (${model}) section (${report.ident})`);
     if (content[model]) {
       // sanitize html comment if it's not null
       if (model === 'analystComments' && content[model].comments) {

--- a/test/reportUpload.test.js
+++ b/test/reportUpload.test.js
@@ -176,6 +176,16 @@ describe('Tests for uploading a report and all of its components', () => {
     })]));
   });
 
+  test('MSI created once', async () => {
+    const msi = await db.models.msi.findAll({where: {reportId}});
+    expect(msi).toHaveProperty('length', 1);
+  });
+
+  test('TMBUR created once', async () => {
+    const tmb = await db.models.tmburMutationBurden.findAll({where: {reportId}});
+    expect(tmb).toHaveProperty('length', 1);
+  });
+
   test('Template was linked correctly', async () => {
     // Get Report and test that the template data in the report is correct
     const report = await db.models.report.findOne({where: {id: reportId}, attributes: ['templateId']});


### PR DESCRIPTION
Ensures only one record is created for non-gene-linked variants when reports are uploaded.