### PR TITLE
Feat/devsu 2539 create tags at report upload

### DIFF
--- a/app/libs/createReport.js
+++ b/app/libs/createReport.js
@@ -275,37 +275,9 @@ const createReportVariantsSection = async (reportId, genesRecordsByName, modelNa
       keyCheck.add(key);
     }
   }
-  let resultWithKeys;
   try {
     if (modelName === 'structuralVariants') {
-      // add the gene FK associations
-      /* const preparedInput = sectionContent.map(({key, gene1, gene2, annotations = [], ...newEntry}) => {
-        return {
-          key,
-          annotations,
-          values: {
-            ...newEntry,
-            reportId,
-            gene1Id: genesRecordsByName[gene1],
-            gene2Id: genesRecordsByName[gene2],
-          },
-        };
-      });
-      // Perform the bulkCreate, but only send the DB-compatible values
-      const createdRecords = await db.models[modelName].bulkCreate(
-        preparedInput.map((entry) => {return entry.values;}),
-        options,
-      );
-
-      // Re-associate the key with the created records
-      resultWithKeys = createdRecords.map((record, index) => {
-        return {
-          ...record.get({plain: true}), // or record.toJSON()
-          key: preparedInput[index].key,
-          annotations: preparedInput[index].annotations,
-        };
-      });
-      */ records = await db.models[modelName].bulkCreate(sectionContent.map(({
+      records = await db.models[modelName].bulkCreate(sectionContent.map(({
         key, gene1, gene2, ...newEntry
       }) => {
         return {
@@ -314,10 +286,8 @@ const createReportVariantsSection = async (reportId, genesRecordsByName, modelNa
           gene1Id: genesRecordsByName[gene1],
           gene2Id: genesRecordsByName[gene2],
         };
-      }), options); /**/
+      }), options);
     } else {
-      // add the gene FK association
-
       records = await db.models[modelName].bulkCreate(sectionContent.map(({key, gene, ...newEntry}) => {
         return {
           ...newEntry,
@@ -325,32 +295,6 @@ const createReportVariantsSection = async (reportId, genesRecordsByName, modelNa
           geneId: genesRecordsByName[gene],
         };
       }), options);
-      /*
-      const preparedInput = sectionContent.map(({key, gene, annotations = [], ...newEntry}) => {
-        return {
-          key,
-          annotations,
-          values: {
-            ...newEntry,
-            reportId,
-            geneId: genesRecordsByName[gene],
-          },
-        };
-      });
-      // Perform the bulkCreate, but only send the DB-compatible values
-      const createdRecords = await db.models[modelName].bulkCreate(
-        preparedInput.map((entry) => {return entry.values;}),
-        options,
-      );
-
-      // Re-associate the key with the created records
-      resultWithKeys = createdRecords.map((record, index) => {
-        return {
-          ...record.get({plain: true}), // or record.toJSON()
-          key: preparedInput[index].key,
-          annotations: preparedInput[index].annotations,
-        };
-      }); */
     }
   } catch (error) {
     throw new Error(`Unable to create variant section (${modelName}) ${error.message || error}`);
@@ -412,7 +356,7 @@ const createReportVariantSections = async (report, content, transaction) => {
     return {...annotation, variantId: variantMapping[variantType][variant], variantType, variant};
   });
 
-  const createdObservedVariantAnnotations = await createReportObservedVariantAnnotationSection(report.id, 'observedVariantAnnotations', observedVariantAnnotations, {transaction});
+  await createReportObservedVariantAnnotationSection(report.id, 'observedVariantAnnotations', observedVariantAnnotations, {transaction});
 };
 
 /**

--- a/app/libs/createReport.js
+++ b/app/libs/createReport.js
@@ -131,7 +131,6 @@ const createStatementMatching = async (reportId, content, createdKbMatches, tran
  * Creates a new section for the report with the provided data
  *
  * @param {Number} reportId - The id of the report this section belongs to
- * @param {string} modelName - Name of the model for this section
  * @param {Array|Object} sectionContent - The record or records to be created for this section
  * @param {object} options - Options for creating report sections
  * @property {object} options.transaction - Transaction to run bulkCreate under
@@ -356,7 +355,7 @@ const createReportVariantSections = async (report, content, transaction) => {
     return {...annotation, variantId: variantMapping[variantType][variant], variantType, variant};
   });
 
-  await createReportObservedVariantAnnotationSection(report.id, 'observedVariantAnnotations', observedVariantAnnotations, {transaction});
+  await createReportObservedVariantAnnotationSection(report.id, observedVariantAnnotations, {transaction});
 };
 
 /**

--- a/app/libs/createReport.js
+++ b/app/libs/createReport.js
@@ -159,7 +159,7 @@ const createReportObservedVariantAnnotationSection = async (reportId, sectionCon
     }
     return retvals;
   } catch (error) {
-    throw new Error(`Unable to create section (${modelName}): ${error.message || error}`);
+    throw new Error(`Unable to create section observedVariantAnnotation: ${error.message || error}`);
   }
 };
 

--- a/app/libs/createReport.js
+++ b/app/libs/createReport.js
@@ -137,7 +137,7 @@ const createStatementMatching = async (reportId, content, createdKbMatches, tran
  *
  * @returns {undefined}
  */
-const createReportObservedVariantAnnotationSection = async (reportId, modelName, sectionContent, options = {}) => {
+const createReportObservedVariantAnnotationSection = async (reportId, sectionContent, options = {}) => {
   const records = Array.isArray(sectionContent)
     ? sectionContent
     : [sectionContent];

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -424,6 +424,13 @@ for (const [pivotValue, modelName] of Object.entries(KB_PIVOT_MAPPING)) {
   });
 }
 
+observedVariantAnnotations.belongsTo(analysisReports, {
+  as: 'report', foreignKey: 'reportId', targetKey: 'id', onDelete: 'CASCADE', constraints: true, foreignKeyConstraint: true,
+});
+analysisReports.hasMany(observedVariantAnnotations, {
+  as: 'observedVariantAnnotations', foreignKey: 'reportId', onDelete: 'CASCADE', constraints: true, foreignKeyConstraint: true,
+});
+
 // Presentation Data
 const presentation = {};
 presentation.discussion = require('./reports/genomic/presentation/discussion.model')(sequelize, Sq);

--- a/app/schemas/report/reportUpload/index.js
+++ b/app/schemas/report/reportUpload/index.js
@@ -2,6 +2,7 @@ const db = require('../../../models');
 const {BASE_EXCLUDE} = require('../../exclude');
 const variantSchemas = require('./variant');
 const kbMatchesSchema = require('./kbMatches');
+const observedVariantAnnotationsSchema = require('./observedVariantAnnotations');
 const schemaGenerator = require('../../schemaGenerator');
 const {UPLOAD_BASE_URI} = require('../../../constants');
 
@@ -68,7 +69,7 @@ const generateReportUploadSchema = (isJsonSchema) => {
     presentationSlides, users, projects, ...associations
   } = db.models.report.associations;
 
-  schema.definitions = {...variantSchemas(isJsonSchema), kbMatches: kbMatchesSchema(isJsonSchema)};
+  schema.definitions = {...variantSchemas(isJsonSchema), kbMatches: kbMatchesSchema(isJsonSchema), observedVariantAnnotations: observedVariantAnnotationsSchema(isJsonSchema)};
 
   // add all associated schemas
   Object.values(associations).forEach((association) => {
@@ -87,6 +88,7 @@ const generateReportUploadSchema = (isJsonSchema) => {
     }
   });
 
+  console.dir(schema.properties);
   return schema;
 };
 

--- a/app/schemas/report/reportUpload/index.js
+++ b/app/schemas/report/reportUpload/index.js
@@ -87,8 +87,6 @@ const generateReportUploadSchema = (isJsonSchema) => {
       schema.definitions[model] = generatedSchema;
     }
   });
-
-  console.dir(schema.properties);
   return schema;
 };
 

--- a/app/schemas/report/reportUpload/observedVariantAnnotations.js
+++ b/app/schemas/report/reportUpload/observedVariantAnnotations.js
@@ -1,0 +1,18 @@
+const db = require('../../../models');
+const schemaGenerator = require('../../schemaGenerator');
+const {REPORT_EXCLUDE} = require('../../exclude');
+
+module.exports = (isJsonSchema) => {
+  return schemaGenerator(db.models.observedVariantAnnotations, {
+    isJsonSchema,
+    properties: {
+      variant: {
+        type: 'string', description: 'the variant key linking this to one of the variant records',
+      },
+      annotations: {type: 'object', description: 'json annotations'},
+    },
+    isSubSchema: true,
+    exclude: [...REPORT_EXCLUDE, 'variantId'],
+    required: ['variant'],
+  });
+};

--- a/test/reportUpload.test.js
+++ b/test/reportUpload.test.js
@@ -226,6 +226,19 @@ describe('Tests for uploading a report and all of its components', () => {
     expect(totalExpectedStatements).toEqual(kbStatements.length);
   });
 
+  test('ObservedVariantAnnotations are linked correctly to observed variants', async () => {
+    const muts = await db.models.smallMutations.findAll({where: {report_id: reportId}});
+    const test3mut = muts.filter((mut) => {
+      return mut.hgvsProtein === 'ZFP36L2:p.Q111del-test3';
+    })[0]
+    const annotations = await db.models.observedVariantAnnotations.findAll({where: {report_id: reportId}});
+    const test3annotation = annotations.filter((ann) => {
+      return ann.annotations['isThisAnObservedVariantAnnotationsTest']
+    })[0]
+    expect(test3annotation.variantType).toEqual('mut');
+    expect(test3annotation.variantId).toEqual(test3mut.id)
+  });
+
   test('One variant record created for each input kbmatch record', async () => {
     const variants = mockReportData.kbMatches;
     expect(variants.length).toEqual(kbVariants.length);

--- a/test/reportUpload.test.js
+++ b/test/reportUpload.test.js
@@ -230,13 +230,13 @@ describe('Tests for uploading a report and all of its components', () => {
     const muts = await db.models.smallMutations.findAll({where: {report_id: reportId}});
     const test3mut = muts.filter((mut) => {
       return mut.hgvsProtein === 'ZFP36L2:p.Q111del-test3';
-    })[0]
+    })[0];
     const annotations = await db.models.observedVariantAnnotations.findAll({where: {report_id: reportId}});
     const test3annotation = annotations.filter((ann) => {
-      return ann.annotations['isThisAnObservedVariantAnnotationsTest']
-    })[0]
+      return ann.annotations.isThisAnObservedVariantAnnotationsTest;
+    })[0];
     expect(test3annotation.variantType).toEqual('mut');
-    expect(test3annotation.variantId).toEqual(test3mut.id)
+    expect(test3annotation.variantId).toEqual(test3mut.id);
   });
 
   test('One variant record created for each input kbmatch record', async () => {

--- a/test/testData/mockReportData.json
+++ b/test/testData/mockReportData.json
@@ -496,11 +496,10 @@
     ],
     "observedVariantAnnotations": [
         {
-            "variant": "test2",
+            "variant": "test3",
             "variantType": "mut",
             "annotations": {
-                "rapidReportTableTag": "therapeutic",
-                "isThisATest": true
+                "isThisAnObservedVariantAnnotationsTest": true
             }
         }
     ],
@@ -562,6 +561,34 @@
             "library": "TEST LIBRARY",
             "selected": false,
             "key": "test1"
+        },
+        {
+            "gene": "ZFP36L2",
+            "transcript": "ENST00000282388",
+            "proteinChange": "p.Q999del",
+            "startPosition": 43451739,
+            "endPosition": 43451739,
+            "chromosome": "2",
+            "refSeq": "CCTG",
+            "altSeq": "C",
+            "zygosity": "sub [0/3]",
+            "tumourRefCount": 583,
+            "tumourAltCount": 4,
+            "tumourDepth": 590,
+            "rnaRefCount": 400,
+            "rnaAltCount": 15,
+            "rnaDepth": 415,
+            "normalRefCount": 40,
+            "normalAltCount": 0,
+            "normalDepth": 40,
+            "ncbiBuild": "GRCh37",
+            "hgvsProtein": "ZFP36L2:p.Q111del-test3",
+            "germline": false,
+            "tumourRefCopies": 60,
+            "tumourAltCopies": 20,
+            "library": "TEST LIBRARY",
+            "selected": false,
+            "key": "test3"
         }
     ],
     "mutationSignature": [

--- a/test/testData/mockReportData.json
+++ b/test/testData/mockReportData.json
@@ -494,6 +494,16 @@
             "kbStatementRelated": true
         }
     ],
+    "observedVariantAnnotations": [
+        {
+            "variant": "test2",
+            "variantType": "mut",
+            "annotations": {
+                "rapidReportTableTag": "therapeutic",
+                "isThisATest": true
+            }
+        }
+    ],
     "smallMutations": [
         {
             "gene": "ZFP36L2",


### PR DESCRIPTION
Updates create-report functionality to create observedVariantAnnotations at report load time if these are included in the report json under the section name 'observedVariantAnnotations'. 