### PR TITLE
[DEVSU-2310] add image data to PUT path

### DIFF
--- a/app/routes/legend/index.js
+++ b/app/routes/legend/index.js
@@ -3,7 +3,7 @@ const express = require('express');
 
 const db = require('../../models');
 const logger = require('../../log');
-const {uploadLegendImage} = require('../report/images');
+const {uploadLegendImage, updateLegendImage} = require('../report/images');
 
 const router = express.Router({mergeParams: true});
 
@@ -33,11 +33,19 @@ router.route('/:legend([A-z0-9-]{36})')
     return res.json(req.legend.view('public'));
   })
   .put(async (req, res) => {
+    // Use the first uploaded file, if any, to replace the stored image
+    const [image] = req.files ? Object.values(req.files) : [];
+
     try {
       await db.transaction(async (transaction) => {
-        await req.legend.update(req.body, {userId: req.user.id, transaction});
+        if (image) {
+          await updateLegendImage(req.legend, image, {updates: req.body, userId: req.user.id, transaction});
+        } else {
+          await req.legend.update(req.body, {userId: req.user.id, transaction});
+        }
         await db.models.legend.ensureDefaultExists({transaction});
       });
+      await req.legend.reload();
       return res.json(req.legend.view('public'));
     } catch (error) {
       logger.error(`Error while updating legend image ${error}`);

--- a/app/routes/report/images.js
+++ b/app/routes/report/images.js
@@ -82,7 +82,42 @@ const uploadLegendImage = async (image, options = {}) => {
   }
 };
 
+/**
+ * Resize, reformat and replace the image on an existing legend entry
+ *
+ * @param {object} legend - The legend db instance to update
+ * @param {object} image - The uploaded file, containing a data buffer and name
+ * @param {object} options - An object containing additional update options
+ *
+ * @property {object} options.updates - Additional legend fields to update (e.g. name, default)
+ * @property {Number} options.userId - The id of the user performing the update
+ * @property {object} options.transaction - An optional transaction to run the update under
+ *
+ * @returns {Promise<object>} - Returns the updated legend db entry
+ * @throws {Promise<Error>} - Something goes wrong with image processing and saving entry
+ */
+const updateLegendImage = async (legend, image, options = {}) => {
+  logger.verbose('Updating legend image');
+
+  const config = {format: DEFAULT_FORMAT, size: IMAGE_SIZE_LIMIT};
+
+  try {
+    const imageData = await processImage(image.data, config.size, config.format);
+
+    return legend.update({
+      ...options.updates,
+      format: config.format,
+      filename: image.name.trim(),
+      data: imageData,
+    }, {userId: options.userId, transaction: options.transaction});
+  } catch (error) {
+    logger.error(`Error processing legend image ${image.name} ${error}`);
+    throw new Error(`Error processing legend image ${image.name} ${error}`);
+  }
+};
+
 module.exports = {
   uploadReportImage,
   uploadLegendImage,
+  updateLegendImage,
 };

--- a/test/routes/legend/legend.test.js
+++ b/test/routes/legend/legend.test.js
@@ -230,6 +230,49 @@ describe('/legend', () => {
       expect(updatedSecondLegend.default).toBe(true);
       expect(updatedFirstLegend.default).toBe(false);
     });
+
+    test('/{legend} - uploading a new image replaces the stored image', async () => {
+      const legend = await db.models.legend.create(
+        buildLegendData({data: 'oldData', filename: 'old.png'}),
+      );
+
+      const res = await request
+        .put(`/api/legend/${legend.ident}`)
+        .attach('image', 'test/testData/images/golden.jpg')
+        .field('name', 'updated name')
+        .auth(username, password)
+        .expect(HTTP_STATUS.OK);
+
+      checkLegend(res.body);
+      expect(res.body.name).toBe('updated name');
+      expect(res.body.filename).toBe('golden.jpg');
+      expect(res.body.format).toBe('PNG');
+      expect(res.body.data).not.toBe('oldData');
+
+      // The replacement is persisted, not just reflected in the response
+      const updated = await db.models.legend.findByPk(legend.id);
+      expect(updated.data).not.toBe('oldData');
+      expect(updated.filename).toBe('golden.jpg');
+    });
+
+    test('/{legend} - metadata-only update preserves the existing image', async () => {
+      const legend = await db.models.legend.create(
+        buildLegendData({data: 'keepThisData', name: 'original'}),
+      );
+
+      const res = await request
+        .put(`/api/legend/${legend.ident}`)
+        .send({name: 'renamed'})
+        .auth(username, password)
+        .type('json')
+        .expect(HTTP_STATUS.OK);
+
+      expect(res.body.name).toBe('renamed');
+      expect(res.body.data).toBe('keepThisData');
+
+      const updated = await db.models.legend.findByPk(legend.id);
+      expect(updated.data).toBe('keepThisData');
+    });
   });
 });
 


### PR DESCRIPTION
Noticed PUT wasn't using new image data, so the front-end edit did nothing cept change name

- Add updateLegendImage helper that processes an uploaded file and updates the legend's data/format/filename (plus any metadata) within a transaction
- Use it from the PUT route when a file is attached; otherwise fall back to a metadata-only update
- Reload the instance after commit so the response reflects persisted state (fixes stale default flag in the response)
- Add tests for image replacement and metadata-only update
