### PR TITLE
DEVSU-2310 Handle Empty Legends Table

### DIFF
--- a/app/routes/report/summary/pathwayAnalysis.js
+++ b/app/routes/report/summary/pathwayAnalysis.js
@@ -151,6 +151,43 @@ router.route('/')
       req.body.pathway = req.files.pathway.data.toString();
     }
 
+    const legendIdProvided = req.body.legendId !== undefined
+      && req.body.legendId !== null
+      && req.body.legendId !== '';
+
+    // If no legendId was provided, try to attach the default legend.
+    // If there are no legend records, leave legendId as null.
+    if (!legendIdProvided) {
+      try {
+        const defaultLegend = await db.models.legend.findOne({where: {default: true}});
+        req.body.legendId = defaultLegend ? defaultLegend.id : null;
+      } catch (error) {
+        logger.error(`Unable to lookup default legend error: ${error}`);
+        return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
+          error: {message: 'Unable to lookup default legend'},
+        });
+      }
+    }
+
+    // If a legendId is present (either provided by caller or default-resolved),
+    // ensure the legend row exists before creating the pathway analysis.
+    if (req.body.legendId !== null && req.body.legendId !== undefined && req.body.legendId !== '') {
+      try {
+        const legend = await db.models.legend.findByPk(req.body.legendId);
+        if (!legend) {
+          logger.error(`Unable to find legend id ${req.body.legendId}`);
+          return res.status(HTTP_STATUS.BAD_REQUEST).json({
+            error: {message: 'Invalid legend id'},
+          });
+        }
+      } catch (error) {
+        logger.error(`Unable to lookup legend id ${req.body.legendId} error: ${error}`);
+        return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
+          error: {message: 'Unable to lookup legend'},
+        });
+      }
+    }
+
     try {
       // validate against the model
       validateAgainstSchema(createSchema, req.body);
@@ -162,21 +199,6 @@ router.route('/')
 
     // Add reports id to request
     req.body.reportId = req.report.id;
-
-    // Associate the default legend image if none was explicitly provided
-    if (!req.body.legendId) {
-      try {
-        const defaultLegend = await db.models.legend.findOne({where: {default: true}});
-        if (defaultLegend) {
-          req.body.legendId = defaultLegend.id;
-        }
-      } catch (error) {
-        logger.error(`Unable to lookup default legend error: ${error}`);
-        return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
-          error: {message: 'Unable to lookup default legend'},
-        });
-      }
-    }
 
     try {
       const result = await db.models.pathwayAnalysis.create(req.body);

--- a/app/routes/report/summary/pathwayAnalysis.js
+++ b/app/routes/report/summary/pathwayAnalysis.js
@@ -90,6 +90,23 @@ router.route('/')
       req.body.legendId = legend.id;
     }
 
+    const legendIdProvided = req.body.legendId !== undefined
+      && req.body.legendId !== null
+      && req.body.legendId !== '';
+
+    if (legendIdProvided) {
+      const parsedLegendId = Number(req.body.legendId);
+      const isValidLegendId = Number.isInteger(parsedLegendId) && parsedLegendId > 0;
+      if (!isValidLegendId) {
+        logger.error(`Invalid legend id provided: ${req.body.legendId}`);
+        return res.status(HTTP_STATUS.BAD_REQUEST).json({
+          error: {message: 'Invalid legend id'},
+        });
+      }
+
+      req.body.legendId = parsedLegendId;
+    }
+
     try {
       // validate against the model
       validateAgainstSchema(updateSchema, req.body, false);
@@ -154,6 +171,19 @@ router.route('/')
     const legendIdProvided = req.body.legendId !== undefined
       && req.body.legendId !== null
       && req.body.legendId !== '';
+
+    if (legendIdProvided) {
+      const parsedLegendId = Number(req.body.legendId);
+      const isValidLegendId = Number.isInteger(parsedLegendId) && parsedLegendId > 0;
+      if (!isValidLegendId) {
+        logger.error(`Invalid legend id provided: ${req.body.legendId}`);
+        return res.status(HTTP_STATUS.BAD_REQUEST).json({
+          error: {message: 'Invalid legend id'},
+        });
+      }
+
+      req.body.legendId = parsedLegendId;
+    }
 
     // If no legendId was provided, try to attach the default legend.
     // If there are no legend records, leave legendId as null.

--- a/migrations/v8.7.0/20260421000001-DEVSU-2310-update-pathway-analysis-legend-fk.js
+++ b/migrations/v8.7.0/20260421000001-DEVSU-2310-update-pathway-analysis-legend-fk.js
@@ -17,7 +17,7 @@ module.exports = {
 
       // Datafix: map existing legend values to legend_id using legends table
       await queryInterface.sequelize.query(
-        `UPDATE "${TABLE}" SET legend_id = l.id FROM pathway_analysis_legends l WHERE "${TABLE}".legend::text = l.name AND EXISTS (SELECT 1 FROM pathway_analysis_legends);`,
+        `UPDATE "${TABLE}" SET legend_id = l.id FROM pathway_analysis_legends l WHERE "${TABLE}".legend::text = l.name;`,
         {transaction},
       );
 
@@ -43,7 +43,7 @@ module.exports = {
 
       // Datafix: restore legend enum value from linked legend name where possible
       await queryInterface.sequelize.query(
-        `UPDATE "${TABLE}" SET legend = l.name::"enum_reports_summary_pathway_analysis_legend" FROM pathway_analysis_legends l WHERE "${TABLE}".legend_id = l.id AND l.name IN ('v1', 'v2', 'v3', 'custom') AND EXISTS (SELECT 1 FROM pathway_analysis_legends);`,
+        `UPDATE "${TABLE}" SET legend = l.name::"enum_reports_summary_pathway_analysis_legend" FROM pathway_analysis_legends l WHERE "${TABLE}".legend_id = l.id AND l.name IN ('v1', 'v2', 'v3', 'custom');`,
         {transaction},
       );
 

--- a/migrations/v8.7.0/20260421000001-DEVSU-2310-update-pathway-analysis-legend-fk.js
+++ b/migrations/v8.7.0/20260421000001-DEVSU-2310-update-pathway-analysis-legend-fk.js
@@ -17,7 +17,7 @@ module.exports = {
 
       // Datafix: map existing legend values to legend_id using legends table
       await queryInterface.sequelize.query(
-        `UPDATE "${TABLE}" SET legend_id = l.id FROM pathway_analysis_legends l WHERE "${TABLE}".legend::text = l.name;`,
+        `UPDATE "${TABLE}" SET legend_id = l.id FROM pathway_analysis_legends l WHERE "${TABLE}".legend::text = l.name AND EXISTS (SELECT 1 FROM pathway_analysis_legends);`,
         {transaction},
       );
 
@@ -43,7 +43,7 @@ module.exports = {
 
       // Datafix: restore legend enum value from linked legend name where possible
       await queryInterface.sequelize.query(
-        `UPDATE "${TABLE}" SET legend = l.name::"enum_reports_summary_pathway_analysis_legend" FROM pathway_analysis_legends l WHERE "${TABLE}".legend_id = l.id AND l.name IN ('v1', 'v2', 'v3', 'custom');`,
+        `UPDATE "${TABLE}" SET legend = l.name::"enum_reports_summary_pathway_analysis_legend" FROM pathway_analysis_legends l WHERE "${TABLE}".legend_id = l.id AND l.name IN ('v1', 'v2', 'v3', 'custom') AND EXISTS (SELECT 1 FROM pathway_analysis_legends);`,
         {transaction},
       );
 

--- a/test/routes/legend/legend.test.js
+++ b/test/routes/legend/legend.test.js
@@ -5,6 +5,7 @@ const db = require('../../../app/models');
 
 const CONFIG = require('../../../app/config');
 const {listen} = require('../../../app');
+
 const {Op} = db.Sequelize;
 
 CONFIG.set('env', 'test');

--- a/test/routes/legend/legend.test.js
+++ b/test/routes/legend/legend.test.js
@@ -5,12 +5,14 @@ const db = require('../../../app/models');
 
 const CONFIG = require('../../../app/config');
 const {listen} = require('../../../app');
+const {Op} = db.Sequelize;
 
 CONFIG.set('env', 'test');
 const {username, password} = CONFIG.get('testing');
 
 let server;
 let request;
+const TEST_PREFIX = `legend-route-test-${Date.now()}-${process.pid}`;
 
 const legendProperties = [
   'ident', 'createdAt', 'updatedAt', 'format', 'filename',
@@ -41,7 +43,7 @@ describe('/legend', () => {
   const buildLegendData = (overrides = {}) => {
     return {
       filename: 'pathway_legend_v1.png',
-      name: 'v1',
+      name: `${TEST_PREFIX}-v1`,
       data: 'v1Data',
       default: false,
       ...overrides,
@@ -55,7 +57,9 @@ describe('/legend', () => {
 
   afterEach(async () => {
     await db.models.legend.destroy({
-      where: {},
+      where: {
+        name: {[Op.like]: `${TEST_PREFIX}%`},
+      },
       force: true,
     });
   });
@@ -88,10 +92,13 @@ describe('/legend', () => {
 
   describe('POST', () => {
     test('POST / - 207 Multi-Status successful', async () => {
+      const uploadFieldName = `${TEST_PREFIX}-v1-upload`;
+      const legendName = `${TEST_PREFIX}-v1`;
+
       const res = await request
         .post('/api/legend')
-        .attach('v1', 'test/testData/images/pathway_legend_v1.png')
-        .field('name', 'v1')
+        .attach(uploadFieldName, 'test/testData/images/pathway_legend_v1.png')
+        .field('name', legendName)
         .auth(username, password)
         .expect(HTTP_STATUS.MULTI_STATUS);
 
@@ -101,26 +108,28 @@ describe('/legend', () => {
 
       const [result] = res.body;
 
-      expect(result.name).toBe('v1');
+      expect(result.name).toBe(uploadFieldName);
       expect(result.upload).toBe('successful');
       expect(result.error).toBe(undefined);
 
-      const legend = await db.models.legend.findOne({where: {name: 'v1'}});
+      const legend = await db.models.legend.findOne({where: {name: legendName}});
       expect(legend).toEqual(expect.objectContaining({
         format: 'PNG',
         filename: 'pathway_legend_v1.png',
-        name: 'v1',
+        name: legendName,
         default: true,
       }));
     });
 
     test('POST / - default=true promotes new legend as only default', async () => {
       const currentDefault = await db.models.legend.create(buildLegendData({default: true}));
+      const uploadFieldName = `${TEST_PREFIX}-golden-upload`;
+      const legendName = `${TEST_PREFIX}-Golden-Test`;
 
       const res = await request
         .post('/api/legend')
-        .attach('golden', 'test/testData/images/golden.jpg')
-        .field('name', 'Golden Test')
+        .attach(uploadFieldName, 'test/testData/images/golden.jpg')
+        .field('name', legendName)
         .field('default', 'true')
         .auth(username, password)
         .expect(HTTP_STATUS.MULTI_STATUS);
@@ -131,12 +140,12 @@ describe('/legend', () => {
 
       const [result] = res.body;
 
-      expect(result.name).toBe('golden');
+      expect(result.name).toBe(uploadFieldName);
       expect(result.upload).toBe('successful');
       expect(result.error).toBe(undefined);
 
       const [newDefault, oldDefault] = await Promise.all([
-        db.models.legend.findOne({where: {name: 'Golden Test'}}),
+        db.models.legend.findOne({where: {name: legendName}}),
         db.models.legend.findByPk(currentDefault.id),
       ]);
 
@@ -235,16 +244,17 @@ describe('/legend', () => {
       const legend = await db.models.legend.create(
         buildLegendData({data: 'oldData', filename: 'old.png'}),
       );
+      const updatedName = `${TEST_PREFIX}-updated-name`;
 
       const res = await request
         .put(`/api/legend/${legend.ident}`)
         .attach('image', 'test/testData/images/golden.jpg')
-        .field('name', 'updated name')
+        .field('name', updatedName)
         .auth(username, password)
         .expect(HTTP_STATUS.OK);
 
       checkLegend(res.body);
-      expect(res.body.name).toBe('updated name');
+      expect(res.body.name).toBe(updatedName);
       expect(res.body.filename).toBe('golden.jpg');
       expect(res.body.format).toBe('PNG');
       expect(res.body.data).not.toBe('oldData');
@@ -257,17 +267,18 @@ describe('/legend', () => {
 
     test('/{legend} - metadata-only update preserves the existing image', async () => {
       const legend = await db.models.legend.create(
-        buildLegendData({data: 'keepThisData', name: 'original'}),
+        buildLegendData({data: 'keepThisData', name: `${TEST_PREFIX}-original`}),
       );
+      const renamedValue = `${TEST_PREFIX}-renamed`;
 
       const res = await request
         .put(`/api/legend/${legend.ident}`)
-        .send({name: 'renamed'})
+        .send({name: renamedValue})
         .auth(username, password)
         .type('json')
         .expect(HTTP_STATUS.OK);
 
-      expect(res.body.name).toBe('renamed');
+      expect(res.body.name).toBe(renamedValue);
       expect(res.body.data).toBe('keepThisData');
 
       const updated = await db.models.legend.findByPk(legend.id);

--- a/test/routes/report/summary/pathwayAnalysis.test.js
+++ b/test/routes/report/summary/pathwayAnalysis.test.js
@@ -238,6 +238,25 @@ describe('/reports/{report}/summary/pathway-analysis', () => {
       await db.models.legend.destroy({where: {id: defaultLegend.id}, force: true});
     });
 
+    test('/ - 201 Created - No legend records and no legendId', async () => {
+      await db.models.legend.destroy({where: {}, force: true});
+
+      const res = await request
+        .post(`/api/reports/${report.ident}/summary/pathway-analysis`)
+        .auth(username, password)
+        .type('json')
+        .attach('pathway', 'test/testData/images/pathwayAnalysisData.svg')
+        .expect(HTTP_STATUS.CREATED);
+
+      checkPathwayAnalysis(res.body);
+
+      expect(res.body.pathway).not.toBeNull();
+      expect(res.body.legendId).toBeNull();
+
+      // Remove pathway analysis
+      await db.models.pathwayAnalysis.destroy({where: {ident: res.body.ident}});
+    });
+
     test('/ - 400 Bad request - Invalid legend id', async () => {
       await request
         .post(`/api/reports/${report.ident}/summary/pathway-analysis`)

--- a/test/routes/report/summary/pathwayAnalysis.test.js
+++ b/test/routes/report/summary/pathwayAnalysis.test.js
@@ -3,10 +3,12 @@ const supertest = require('supertest');
 const getPort = require('get-port');
 
 const db = require('../../../../app/models');
+const {Op} = db.Sequelize;
 const CONFIG = require('../../../../app/config');
 const {listen} = require('../../../../app');
 
 CONFIG.set('env', 'test');
+jest.setTimeout(20000);
 const {username, password} = CONFIG.get('testing');
 
 let server;
@@ -32,7 +34,7 @@ beforeAll(async () => {
 
 describe('/reports/{report}/summary/pathway-analysis', () => {
   let report;
-  let legend;
+  const TEST_SUFFIX = `${Date.now()}-${process.pid}`;
 
   beforeAll(async () => {
     // Get genomic template
@@ -41,13 +43,6 @@ describe('/reports/{report}/summary/pathway-analysis', () => {
     report = await db.models.report.create({
       templateId: template.id,
       patientId: 'TESTPATIENT1234',
-    });
-    // Create legend for pathway analysis tests
-    legend = await db.models.legend.create({
-      filename: 'pathway_legend_v1.png',
-      name: 'v1',
-      data: 'v1Data',
-      default: true,
     });
   });
 
@@ -79,16 +74,24 @@ describe('/reports/{report}/summary/pathway-analysis', () => {
 
   describe('PUT', () => {
     let pathwayAnalysis;
+    let legend;
 
     beforeEach(async () => {
       pathwayAnalysis = await db.models.pathwayAnalysis.create({
         reportId: report.id,
+      });
+      legend = await db.models.legend.create({
+        filename: 'pathway_legend_v1.png',
+        name: `put-legend-${TEST_SUFFIX}`,
+        data: 'v1Data',
+        default: false,
       });
     });
 
     // Delete pathway analysis
     afterEach(async () => {
       await db.models.pathwayAnalysis.destroy({where: {ident: pathwayAnalysis.ident}, force: true});
+      await db.models.legend.destroy({where: {id: legend.id}, force: true});
     });
 
     test('/ - 200 Success', async () => {
@@ -175,6 +178,21 @@ describe('/reports/{report}/summary/pathway-analysis', () => {
   });
 
   describe('POST', () => {
+    let legend;
+
+    beforeEach(async () => {
+      legend = await db.models.legend.create({
+        filename: 'pathway_legend_v1.png',
+        name: `post-legend-${TEST_SUFFIX}`,
+        data: 'v1Data',
+        default: false,
+      });
+    });
+
+    afterEach(async () => {
+      await db.models.legend.destroy({where: {id: legend.id}, force: true});
+    });
+
     test('/ - 201 Created', async () => {
       const res = await request
         .post(`/api/reports/${report.ident}/summary/pathway-analysis`)
@@ -194,6 +212,14 @@ describe('/reports/{report}/summary/pathway-analysis', () => {
     });
 
     test('/ - 201 Created - Default legend automatically associated', async () => {
+      await db.models.legend.update({default: false}, {where: {id: legend.id}});
+      const defaultLegend = await db.models.legend.create({
+        filename: 'pathway_legend_v1.png',
+        name: `default-legend-${TEST_SUFFIX}`,
+        data: 'v1Data',
+        default: true,
+      });
+
       const res = await request
         .post(`/api/reports/${report.ident}/summary/pathway-analysis`)
         .auth(username, password)
@@ -204,10 +230,11 @@ describe('/reports/{report}/summary/pathway-analysis', () => {
       checkPathwayAnalysis(res.body);
 
       expect(res.body.pathway).not.toBeNull();
-      expect(res.body.legendId).toBe(legend.id);
+      expect(res.body.legendId).toBe(defaultLegend.id);
 
       // Remove pathway analysis
       await db.models.pathwayAnalysis.destroy({where: {ident: res.body.ident}});
+      await db.models.legend.destroy({where: {id: defaultLegend.id}, force: true});
     });
 
     test('/ - 400 Bad request - Invalid legend id', async () => {
@@ -251,7 +278,19 @@ describe('/reports/{report}/summary/pathway-analysis', () => {
 
   // Delete report
   afterAll(async () => {
-    await db.models.legend.destroy({where: {id: legend.id}, force: true});
+    await db.models.pathwayAnalysis.destroy({where: {reportId: report.id}, force: true});
+    await db.models.legend.destroy({
+      where: {
+        name: {
+          [Op.or]: [
+            {[Op.like]: `put-legend-${TEST_SUFFIX}%`},
+            {[Op.like]: `post-legend-${TEST_SUFFIX}%`},
+            {[Op.like]: `default-legend-${TEST_SUFFIX}%`},
+          ],
+        },
+      },
+      force: true,
+    });
     await db.models.report.destroy({where: {id: report.id}, force: true});
   });
 });

--- a/test/routes/report/summary/pathwayAnalysis.test.js
+++ b/test/routes/report/summary/pathwayAnalysis.test.js
@@ -3,6 +3,7 @@ const supertest = require('supertest');
 const getPort = require('get-port');
 
 const db = require('../../../../app/models');
+
 const {Op} = db.Sequelize;
 const CONFIG = require('../../../../app/config');
 const {listen} = require('../../../../app');


### PR DESCRIPTION
- DEVSU-2310
- Update mock legend image in unit tests with duplicated name with real record
- Update POST method for pathwayAnalysis to handle situations where there are no legend images for the automatic assignment of default legend
- Update POST and PUT handler for PathwayAnalysis to ensure that legendId is a valid integer before proceeding with association
- Add dedicated test for scenario where new pathwayAnalysis record is being created but there are no legends to auto associate