### PR TITLE
hotfix/report-assignment-access-should-have-permission-for-user-search

### DIFF
--- a/app/middleware/acl.js
+++ b/app/middleware/acl.js
@@ -36,7 +36,12 @@ const SPECIAL_CASES = [
   },
   {
     path: pathToRegexp('/api/user/search'),
-    GET: [{name: 'admin'}, {name: 'manager'}, {name: 'create project access'}],
+    GET: [
+      {name: 'admin'},
+      {name: 'manager'},
+      {name: 'create project access'},
+      {name: 'report assignment access'},
+    ],
   },
   {
     path: pathToRegexp('/api/user/:user'),


### PR DESCRIPTION
hotfix for release 8.7.0
- add report assignment access to user search